### PR TITLE
PrettyPrint class is included using lowercase 'pp'

### DIFF
--- a/lib/github_changelog_generator/parser.rb
+++ b/lib/github_changelog_generator/parser.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 require 'optparse'
-require 'PP'
+require 'pp'
 require_relative 'version'
 
 module GitHubChangelogGenerator


### PR DESCRIPTION
PrettyPrint should be required using lowercase 'pp' rather than capital 'PP' to function correctly on case-sensitive filesystems. http://ruby-doc.org/stdlib-2.1.0/libdoc/pp/rdoc/PP.html#method-c-pp

This is a fix for:
```
$ github_changelog_generator
.rbenv/versions/2.1.2/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require': cannot load such file -- PP (LoadError)
```