### PR TITLE
fix link tag format

### DIFF
--- a/lib/github_changelog_generator.rb
+++ b/lib/github_changelog_generator.rb
@@ -321,7 +321,7 @@ module GitHubChangelogGenerator
       github_site = options[:github_site] || 'https://github.com'
 
       # Generate tag name and link
-      log = "## [#{tag_name}] (#{github_site}/#{@options[:user]}/#{@options[:project]}/tree/#{tag_name})\n"
+      log = "## [#{tag_name}](#{github_site}/#{@options[:user]}/#{@options[:project]}/tree/#{tag_name})\n"
 
       #Generate date string:
       time_string = tag_time.strftime @options[:format]


### PR DESCRIPTION
I tried Github-Changelog-Generator. but atom editor "Markdown Preview" is not parsed H2 link tag :sweat_drops: 

I removed extra space of H2 level link tag.

before generate format.
`## [0.0.1] (https://github.com/skywinder/Github-Changelog-Generator/tree/0.0.1)`

after generate format.
`## [0.0.1](https://github.com/skywinder/Github-Changelog-Generator/tree/0.0.1)`

Remove Space is `] (`.