### PR TITLE
Concurrency problem in case of issues > 2048

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 [Full Changelog](https://github.com/skywinder/Github-Changelog-Generator/compare/1.3.6...1.3.8)
 
+**Merged pull requests:**
+
+- Fix `git remote` parsing in case, when script running without parameters inside destination directory [\#61](https://github.com/skywinder/Github-Changelog-Generator/pull/61) ([skywinder](https://github.com/skywinder))
+
 ## [1.3.6](https://github.com/skywinder/Github-Changelog-Generator/tree/1.3.6) (2015-03-05)
 
 [Full Changelog](https://github.com/skywinder/Github-Changelog-Generator/compare/1.3.5...1.3.6)

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Here is a [wikipage list of alternatives](https://github.com/skywinder/Github-Ch
 ### Projects using this library
 [Wikipage with list of projects](https://github.com/skywinder/Github-Changelog-Generator/wiki/Projects-using-Github-Changelog-Generator) 
 
-*If you are using `github_changelog_generator` for generation change log in your project or know of project that uses it, please add it to [this] (https://github.com/skywinder/Github-Changelog-Generator/wiki/Projects-using-Github-Changelog-Generator) list.*
+*If you are using `github_changelog_generator` for generation change log in your project or know another project that uses it, please add it to [this] (https://github.com/skywinder/Github-Changelog-Generator/wiki/Projects-using-Github-Changelog-Generator) list.*
 
 ## Am I missed some essential feature?
 

--- a/lib/CHANGELOG.md
+++ b/lib/CHANGELOG.md
@@ -1,280 +1,30 @@
 # Change Log
 
-## [1.3.8](https://github.com/skywinder/Github-Changelog-Generator/tree/1.3.8) (2015-03-05)
+## [Unreleased](https://github.com/skywinder/changelog_test/tree/HEAD)
 
-[Full Changelog](https://github.com/skywinder/Github-Changelog-Generator/compare/1.3.6...1.3.8)
-
-**Merged pull requests:**
-
-- Fix `git remote` parsing in case, when script running without parameters inside destination directory [\#61](https://github.com/skywinder/Github-Changelog-Generator/pull/61) ([skywinder](https://github.com/skywinder))
-
-## [1.3.6](https://github.com/skywinder/Github-Changelog-Generator/tree/1.3.6) (2015-03-05)
-
-[Full Changelog](https://github.com/skywinder/Github-Changelog-Generator/compare/1.3.5...1.3.6)
-
-## [1.3.5](https://github.com/skywinder/Github-Changelog-Generator/tree/1.3.5) (2015-03-04)
-
-[Full Changelog](https://github.com/skywinder/Github-Changelog-Generator/compare/1.3.4...1.3.5)
-
-**Fixed bugs:**
-
-- Pull Requests in Wrong Tag [\#60](https://github.com/skywinder/Github-Changelog-Generator/issues/60)
-
-## [1.3.4](https://github.com/skywinder/Github-Changelog-Generator/tree/1.3.4) (2015-03-03)
-
-[Full Changelog](https://github.com/skywinder/Github-Changelog-Generator/compare/1.3.3...1.3.4)
-
-**Fixed bugs:**
-
-- --no-issues appears to break PRs [\#59](https://github.com/skywinder/Github-Changelog-Generator/issues/59)
-
-## [1.3.3](https://github.com/skywinder/Github-Changelog-Generator/tree/1.3.3) (2015-03-03)
-
-[Full Changelog](https://github.com/skywinder/Github-Changelog-Generator/compare/1.3.2...1.3.3)
-
-**Closed issues:**
-
-- Add \# character to encapsulate list. [\#58](https://github.com/skywinder/Github-Changelog-Generator/issues/58)
-
-## [1.3.2](https://github.com/skywinder/Github-Changelog-Generator/tree/1.3.2) (2015-03-03)
-
-[Full Changelog](https://github.com/skywinder/Github-Changelog-Generator/compare/1.3.1...1.3.2)
-
-**Fixed bugs:**
-
-- generation failed if github commit api return `404 Not Found` [\#57](https://github.com/skywinder/Github-Changelog-Generator/issues/57)
-
-## [1.3.1](https://github.com/skywinder/Github-Changelog-Generator/tree/1.3.1) (2015-02-27)
-
-[Full Changelog](https://github.com/skywinder/Github-Changelog-Generator/compare/1.3.0...1.3.1)
-
-## [1.3.0](https://github.com/skywinder/Github-Changelog-Generator/tree/1.3.0) (2015-02-26)
-
-[Full Changelog](https://github.com/skywinder/Github-Changelog-Generator/compare/1.2.8...1.3.0)
-
-**Implemented enhancements:**
-
-- Do not show `Unreleased` section, when it's empty. [\#55](https://github.com/skywinder/Github-Changelog-Generator/issues/55)
-
-- Separate list exclude and include labels [\#52](https://github.com/skywinder/Github-Changelog-Generator/issues/52)
-
-- Unreleased issues in separate section [\#47](https://github.com/skywinder/Github-Changelog-Generator/issues/47)
-
-- Separate by lists: Enhancements, Bugs, Pull requests. [\#31](https://github.com/skywinder/Github-Changelog-Generator/issues/31)
-
-**Fixed bugs:**
-
-- Test pull request with invalid label \(\#26\) in changelog appeared. [\#44](https://github.com/skywinder/Github-Changelog-Generator/issues/44)
+[Full Changelog](https://github.com/skywinder/changelog_test/compare/v0.0.3...HEAD)
 
 **Merged pull requests:**
 
-- Implement filtering of Pull Requests by milestones [\#50](https://github.com/skywinder/Github-Changelog-Generator/pull/50) ([skywinder](https://github.com/skywinder))
+- Add automatically generated change log file. [\#5](https://github.com/skywinder/changelog_test/pull/5) ([skywinder](https://github.com/skywinder))
 
-## [1.2.8](https://github.com/skywinder/Github-Changelog-Generator/tree/1.2.8) (2015-02-17)
+## [v0.0.3](https://github.com/skywinder/changelog_test/tree/v0.0.3) (2015-03-04)
 
-[Full Changelog](https://github.com/skywinder/Github-Changelog-Generator/compare/1.2.7...1.2.8)
-
-**Closed issues:**
-
-- Bugs, that closed simultaneously with push not appeared in correct version. [\#37](https://github.com/skywinder/Github-Changelog-Generator/issues/37)
+[Full Changelog](https://github.com/skywinder/changelog_test/compare/v0.0.2...v0.0.3)
 
 **Merged pull requests:**
 
-- Feature/fix 37 [\#49](https://github.com/skywinder/Github-Changelog-Generator/pull/49) ([skywinder](https://github.com/skywinder))
+- fix \#3. hotfix. Should appear in v0.0.3 [\#4](https://github.com/skywinder/changelog_test/pull/4) ([skywinder](https://github.com/skywinder))
 
-- Prettify output [\#48](https://github.com/skywinder/Github-Changelog-Generator/pull/48) ([skywinder](https://github.com/skywinder))
+## [v0.0.2](https://github.com/skywinder/changelog_test/tree/v0.0.2) (2015-03-04)
 
-## [1.2.7](https://github.com/skywinder/Github-Changelog-Generator/tree/1.2.7) (2015-01-26)
-
-[Full Changelog](https://github.com/skywinder/Github-Changelog-Generator/compare/1.2.6...1.2.7)
+[Full Changelog](https://github.com/skywinder/changelog_test/compare/v0.0.1...v0.0.2)
 
 **Merged pull requests:**
 
-- Add compare link between older version and newer version [\#46](https://github.com/skywinder/Github-Changelog-Generator/pull/46) ([sue445](https://github.com/sue445))
+- Here is a test hotfix should appear in v.0.0.2 [\#2](https://github.com/skywinder/changelog_test/pull/2) ([skywinder](https://github.com/skywinder))
 
-## [1.2.6](https://github.com/skywinder/Github-Changelog-Generator/tree/1.2.6) (2015-01-21)
-
-[Full Changelog](https://github.com/skywinder/Github-Changelog-Generator/compare/1.2.5...1.2.6)
-
-**Merged pull requests:**
-
-- fix link tag format [\#45](https://github.com/skywinder/Github-Changelog-Generator/pull/45) ([sugamasao](https://github.com/sugamasao))
-
-## [1.2.5](https://github.com/skywinder/Github-Changelog-Generator/tree/1.2.5) (2015-01-15)
-
-[Full Changelog](https://github.com/skywinder/Github-Changelog-Generator/compare/1.2.4...1.2.5)
-
-**Implemented enhancements:**
-
-- Use milestone to specify in which version bug was fixed [\#22](https://github.com/skywinder/Github-Changelog-Generator/issues/22)
-
-**Fixed bugs:**
-
-- Error when trying to generate log for repo without tags [\#32](https://github.com/skywinder/Github-Changelog-Generator/issues/32)
-
-**Merged pull requests:**
-
-- PrettyPrint class is included using lowercase 'pp' [\#43](https://github.com/skywinder/Github-Changelog-Generator/pull/43) ([schwing](https://github.com/schwing))
-
-- support enterprise github via command line options [\#42](https://github.com/skywinder/Github-Changelog-Generator/pull/42) ([glenlovett](https://github.com/glenlovett))
-
-## [1.2.4](https://github.com/skywinder/Github-Changelog-Generator/tree/1.2.4) (2014-12-16)
-
-[Full Changelog](https://github.com/skywinder/Github-Changelog-Generator/compare/1.2.3...1.2.4)
-
-**Fixed bugs:**
-
-- Sometimes user is NULL during merges [\#41](https://github.com/skywinder/Github-Changelog-Generator/issues/41)
-
-- Crash when try generate log for rails [\#35](https://github.com/skywinder/Github-Changelog-Generator/issues/35)
-
-## [1.2.3](https://github.com/skywinder/Github-Changelog-Generator/tree/1.2.3) (2014-12-16)
-
-[Full Changelog](https://github.com/skywinder/Github-Changelog-Generator/compare/1.2.2...1.2.3)
-
-**Implemented enhancements:**
-
-- Add ability to run with one parameter instead -u -p [\#38](https://github.com/skywinder/Github-Changelog-Generator/issues/38)
-
-- Detailed output [\#33](https://github.com/skywinder/Github-Changelog-Generator/issues/33)
-
-**Fixed bugs:**
-
-- Docs lacking or basic behavior not as advertised [\#30](https://github.com/skywinder/Github-Changelog-Generator/issues/30)
-
-**Merged pull requests:**
-
-- Implement async fetching [\#39](https://github.com/skywinder/Github-Changelog-Generator/pull/39) ([skywinder](https://github.com/skywinder))
-
-- Fix crash when user is NULL [\#40](https://github.com/skywinder/Github-Changelog-Generator/pull/40) ([skywinder](https://github.com/skywinder))
-
-## [1.2.2](https://github.com/skywinder/Github-Changelog-Generator/tree/1.2.2) (2014-12-10)
-
-[Full Changelog](https://github.com/skywinder/Github-Changelog-Generator/compare/1.2.1...1.2.2)
-
-**Fixed bugs:**
-
-- Encapsulate \[ \> \* \_ \ \] signs in issues names [\#34](https://github.com/skywinder/Github-Changelog-Generator/issues/34)
-
-**Merged pull requests:**
-
-- Add a Bitdeli Badge to README [\#36](https://github.com/skywinder/Github-Changelog-Generator/pull/36) ([bitdeli-chef](https://github.com/bitdeli-chef))
-
-## [1.2.1](https://github.com/skywinder/Github-Changelog-Generator/tree/1.2.1) (2014-11-22)
-
-[Full Changelog](https://github.com/skywinder/Github-Changelog-Generator/compare/1.2.0...1.2.1)
-
-**Fixed bugs:**
-
-- Script fills changelog only for first 30 tags. [\#20](https://github.com/skywinder/Github-Changelog-Generator/issues/20)
-
-**Merged pull requests:**
-
-- Issues for last tag not in list [\#29](https://github.com/skywinder/Github-Changelog-Generator/pull/29) ([skywinder](https://github.com/skywinder))
-
-- Disable default --filter-pull-requests option. [\#28](https://github.com/skywinder/Github-Changelog-Generator/pull/28) ([skywinder](https://github.com/skywinder))
-
-## [1.2.0](https://github.com/skywinder/Github-Changelog-Generator/tree/1.2.0) (2014-11-19)
-
-[Full Changelog](https://github.com/skywinder/Github-Changelog-Generator/compare/1.1.4...1.2.0)
-
-**Merged pull requests:**
-
-- Add filter for pull-requests labels. \(option --filter-pull-requests\) [\#27](https://github.com/skywinder/Github-Changelog-Generator/pull/27) ([skywinder](https://github.com/skywinder))
-
-- Add ability to insert authors of pull-requests \(--\[no-\]author option\) [\#25](https://github.com/skywinder/Github-Changelog-Generator/pull/25) ([skywinder](https://github.com/skywinder))
-
-- Don't receive issues in case of --no-isses flag specied [\#24](https://github.com/skywinder/Github-Changelog-Generator/pull/24) ([skywinder](https://github.com/skywinder))
-
-## [1.1.4](https://github.com/skywinder/Github-Changelog-Generator/tree/1.1.4) (2014-11-18)
-
-[Full Changelog](https://github.com/skywinder/Github-Changelog-Generator/compare/1.1.2...1.1.4)
-
-**Implemented enhancements:**
-
-- Implement ability to retrieve GitHub token from ENV variable \(to not put it to script directly\) [\#19](https://github.com/skywinder/Github-Changelog-Generator/issues/19)
-
-**Merged pull requests:**
-
-- Sort tags by date [\#23](https://github.com/skywinder/Github-Changelog-Generator/pull/23) ([skywinder](https://github.com/skywinder))
-
-## [1.1.2](https://github.com/skywinder/Github-Changelog-Generator/tree/1.1.2) (2014-11-12)
-
-[Full Changelog](https://github.com/skywinder/Github-Changelog-Generator/compare/1.1.1...1.1.2)
-
-**Merged pull requests:**
-
-- Fix bug with dot signs in project name [\#18](https://github.com/skywinder/Github-Changelog-Generator/pull/18) ([skywinder](https://github.com/skywinder))
-
-- Fix bug with dot signs in user name [\#17](https://github.com/skywinder/Github-Changelog-Generator/pull/17) ([skywinder](https://github.com/skywinder))
-
-## [1.1.1](https://github.com/skywinder/Github-Changelog-Generator/tree/1.1.1) (2014-11-10)
-
-[Full Changelog](https://github.com/skywinder/Github-Changelog-Generator/compare/1.1.0...1.1.1)
-
-**Merged pull requests:**
-
-- Remove duplicates of issues and pull-requests with same number [\#15](https://github.com/skywinder/Github-Changelog-Generator/pull/15) ([skywinder](https://github.com/skywinder))
-
-- Sort issues by tags [\#14](https://github.com/skywinder/Github-Changelog-Generator/pull/14) ([skywinder](https://github.com/skywinder))
-
-- Add ability to add or exclude issues without any labels [\#13](https://github.com/skywinder/Github-Changelog-Generator/pull/13) ([skywinder](https://github.com/skywinder))
-
-## [1.1.0](https://github.com/skywinder/Github-Changelog-Generator/tree/1.1.0) (2014-11-10)
-
-[Full Changelog](https://github.com/skywinder/Github-Changelog-Generator/compare/1.0.1...1.1.0)
-
-**Implemented enhancements:**
-
-- Detect username and project form origin [\#11](https://github.com/skywinder/Github-Changelog-Generator/issues/11)
-
-**Fixed bugs:**
-
-- Bug with wrong credentials in 1.0.1 [\#12](https://github.com/skywinder/Github-Changelog-Generator/issues/12)
-
-- Markdown formating in the last line wrong [\#9](https://github.com/skywinder/Github-Changelog-Generator/issues/9)
-
-## [1.0.1](https://github.com/skywinder/Github-Changelog-Generator/tree/1.0.1) (2014-11-10)
-
-[Full Changelog](https://github.com/skywinder/Github-Changelog-Generator/compare/1.0.0...1.0.1)
-
-## [1.0.0](https://github.com/skywinder/Github-Changelog-Generator/tree/1.0.0) (2014-11-07)
-
-[Full Changelog](https://github.com/skywinder/Github-Changelog-Generator/compare/0.1.0...1.0.0)
-
-**Implemented enhancements:**
-
-- Add support for fixed issues and implemented enchanments. [\#6](https://github.com/skywinder/Github-Changelog-Generator/issues/6)
-
-- Implement option to specify output filename [\#4](https://github.com/skywinder/Github-Changelog-Generator/issues/4)
-
-**Fixed bugs:**
-
-- Last tag not appeared in changelog [\#5](https://github.com/skywinder/Github-Changelog-Generator/issues/5)
-
-**Merged pull requests:**
-
-- Implement support of different tags. [\#8](https://github.com/skywinder/Github-Changelog-Generator/pull/8) ([skywinder](https://github.com/skywinder))
-
-- Add support for issues in CHANGELOG [\#7](https://github.com/skywinder/Github-Changelog-Generator/pull/7) ([skywinder](https://github.com/skywinder))
-
-## [0.1.0](https://github.com/skywinder/Github-Changelog-Generator/tree/0.1.0) (2014-11-07)
-
-[Full Changelog](https://github.com/skywinder/Github-Changelog-Generator/compare/0.0.2...0.1.0)
-
-**Merged pull requests:**
-
-- Fix parsing date of pull request [\#3](https://github.com/skywinder/Github-Changelog-Generator/pull/3) ([skywinder](https://github.com/skywinder))
-
-- Add changelog generation for last tag [\#2](https://github.com/skywinder/Github-Changelog-Generator/pull/2) ([skywinder](https://github.com/skywinder))
-
-- Add option \(-o --output\) to specify name of the output file. [\#1](https://github.com/skywinder/Github-Changelog-Generator/pull/1) ([skywinder](https://github.com/skywinder))
-
-## [0.0.2](https://github.com/skywinder/Github-Changelog-Generator/tree/0.0.2) (2014-11-06)
-
-[Full Changelog](https://github.com/skywinder/Github-Changelog-Generator/compare/0.0.1...0.0.2)
-
-## [0.0.1](https://github.com/skywinder/Github-Changelog-Generator/tree/0.0.1) (2014-11-06)
+## [v0.0.1](https://github.com/skywinder/changelog_test/tree/v0.0.1) (2015-03-02)
 
 
 

--- a/lib/CHANGELOG.md
+++ b/lib/CHANGELOG.md
@@ -1,18 +1,280 @@
 # Change Log
 
-## [Unreleased](https://github.com/skywinder/changelog_test/tree/HEAD)
+## [1.3.8](https://github.com/skywinder/Github-Changelog-Generator/tree/1.3.8) (2015-03-05)
 
-[Full Changelog](https://github.com/skywinder/changelog_test/compare/v0.0.2...HEAD)
+[Full Changelog](https://github.com/skywinder/Github-Changelog-Generator/compare/1.3.6...1.3.8)
 
 **Merged pull requests:**
 
-- Here is a test hotfix should appear in v.0.0.2 [\#2](https://github.com/skywinder/changelog_test/pull/2) ([skywinder](https://github.com/skywinder))
+- Fix `git remote` parsing in case, when script running without parameters inside destination directory [\#61](https://github.com/skywinder/Github-Changelog-Generator/pull/61) ([skywinder](https://github.com/skywinder))
 
-## [v0.0.2](https://github.com/skywinder/changelog_test/tree/v0.0.2) (2015-03-04)
+## [1.3.6](https://github.com/skywinder/Github-Changelog-Generator/tree/1.3.6) (2015-03-05)
 
-[Full Changelog](https://github.com/skywinder/changelog_test/compare/v0.0.1...v0.0.2)
+[Full Changelog](https://github.com/skywinder/Github-Changelog-Generator/compare/1.3.5...1.3.6)
 
-## [v0.0.1](https://github.com/skywinder/changelog_test/tree/v0.0.1) (2015-03-02)
+## [1.3.5](https://github.com/skywinder/Github-Changelog-Generator/tree/1.3.5) (2015-03-04)
+
+[Full Changelog](https://github.com/skywinder/Github-Changelog-Generator/compare/1.3.4...1.3.5)
+
+**Fixed bugs:**
+
+- Pull Requests in Wrong Tag [\#60](https://github.com/skywinder/Github-Changelog-Generator/issues/60)
+
+## [1.3.4](https://github.com/skywinder/Github-Changelog-Generator/tree/1.3.4) (2015-03-03)
+
+[Full Changelog](https://github.com/skywinder/Github-Changelog-Generator/compare/1.3.3...1.3.4)
+
+**Fixed bugs:**
+
+- --no-issues appears to break PRs [\#59](https://github.com/skywinder/Github-Changelog-Generator/issues/59)
+
+## [1.3.3](https://github.com/skywinder/Github-Changelog-Generator/tree/1.3.3) (2015-03-03)
+
+[Full Changelog](https://github.com/skywinder/Github-Changelog-Generator/compare/1.3.2...1.3.3)
+
+**Closed issues:**
+
+- Add \# character to encapsulate list. [\#58](https://github.com/skywinder/Github-Changelog-Generator/issues/58)
+
+## [1.3.2](https://github.com/skywinder/Github-Changelog-Generator/tree/1.3.2) (2015-03-03)
+
+[Full Changelog](https://github.com/skywinder/Github-Changelog-Generator/compare/1.3.1...1.3.2)
+
+**Fixed bugs:**
+
+- generation failed if github commit api return `404 Not Found` [\#57](https://github.com/skywinder/Github-Changelog-Generator/issues/57)
+
+## [1.3.1](https://github.com/skywinder/Github-Changelog-Generator/tree/1.3.1) (2015-02-27)
+
+[Full Changelog](https://github.com/skywinder/Github-Changelog-Generator/compare/1.3.0...1.3.1)
+
+## [1.3.0](https://github.com/skywinder/Github-Changelog-Generator/tree/1.3.0) (2015-02-26)
+
+[Full Changelog](https://github.com/skywinder/Github-Changelog-Generator/compare/1.2.8...1.3.0)
+
+**Implemented enhancements:**
+
+- Do not show `Unreleased` section, when it's empty. [\#55](https://github.com/skywinder/Github-Changelog-Generator/issues/55)
+
+- Separate list exclude and include labels [\#52](https://github.com/skywinder/Github-Changelog-Generator/issues/52)
+
+- Unreleased issues in separate section [\#47](https://github.com/skywinder/Github-Changelog-Generator/issues/47)
+
+- Separate by lists: Enhancements, Bugs, Pull requests. [\#31](https://github.com/skywinder/Github-Changelog-Generator/issues/31)
+
+**Fixed bugs:**
+
+- Test pull request with invalid label \(\#26\) in changelog appeared. [\#44](https://github.com/skywinder/Github-Changelog-Generator/issues/44)
+
+**Merged pull requests:**
+
+- Implement filtering of Pull Requests by milestones [\#50](https://github.com/skywinder/Github-Changelog-Generator/pull/50) ([skywinder](https://github.com/skywinder))
+
+## [1.2.8](https://github.com/skywinder/Github-Changelog-Generator/tree/1.2.8) (2015-02-17)
+
+[Full Changelog](https://github.com/skywinder/Github-Changelog-Generator/compare/1.2.7...1.2.8)
+
+**Closed issues:**
+
+- Bugs, that closed simultaneously with push not appeared in correct version. [\#37](https://github.com/skywinder/Github-Changelog-Generator/issues/37)
+
+**Merged pull requests:**
+
+- Feature/fix 37 [\#49](https://github.com/skywinder/Github-Changelog-Generator/pull/49) ([skywinder](https://github.com/skywinder))
+
+- Prettify output [\#48](https://github.com/skywinder/Github-Changelog-Generator/pull/48) ([skywinder](https://github.com/skywinder))
+
+## [1.2.7](https://github.com/skywinder/Github-Changelog-Generator/tree/1.2.7) (2015-01-26)
+
+[Full Changelog](https://github.com/skywinder/Github-Changelog-Generator/compare/1.2.6...1.2.7)
+
+**Merged pull requests:**
+
+- Add compare link between older version and newer version [\#46](https://github.com/skywinder/Github-Changelog-Generator/pull/46) ([sue445](https://github.com/sue445))
+
+## [1.2.6](https://github.com/skywinder/Github-Changelog-Generator/tree/1.2.6) (2015-01-21)
+
+[Full Changelog](https://github.com/skywinder/Github-Changelog-Generator/compare/1.2.5...1.2.6)
+
+**Merged pull requests:**
+
+- fix link tag format [\#45](https://github.com/skywinder/Github-Changelog-Generator/pull/45) ([sugamasao](https://github.com/sugamasao))
+
+## [1.2.5](https://github.com/skywinder/Github-Changelog-Generator/tree/1.2.5) (2015-01-15)
+
+[Full Changelog](https://github.com/skywinder/Github-Changelog-Generator/compare/1.2.4...1.2.5)
+
+**Implemented enhancements:**
+
+- Use milestone to specify in which version bug was fixed [\#22](https://github.com/skywinder/Github-Changelog-Generator/issues/22)
+
+**Fixed bugs:**
+
+- Error when trying to generate log for repo without tags [\#32](https://github.com/skywinder/Github-Changelog-Generator/issues/32)
+
+**Merged pull requests:**
+
+- PrettyPrint class is included using lowercase 'pp' [\#43](https://github.com/skywinder/Github-Changelog-Generator/pull/43) ([schwing](https://github.com/schwing))
+
+- support enterprise github via command line options [\#42](https://github.com/skywinder/Github-Changelog-Generator/pull/42) ([glenlovett](https://github.com/glenlovett))
+
+## [1.2.4](https://github.com/skywinder/Github-Changelog-Generator/tree/1.2.4) (2014-12-16)
+
+[Full Changelog](https://github.com/skywinder/Github-Changelog-Generator/compare/1.2.3...1.2.4)
+
+**Fixed bugs:**
+
+- Sometimes user is NULL during merges [\#41](https://github.com/skywinder/Github-Changelog-Generator/issues/41)
+
+- Crash when try generate log for rails [\#35](https://github.com/skywinder/Github-Changelog-Generator/issues/35)
+
+## [1.2.3](https://github.com/skywinder/Github-Changelog-Generator/tree/1.2.3) (2014-12-16)
+
+[Full Changelog](https://github.com/skywinder/Github-Changelog-Generator/compare/1.2.2...1.2.3)
+
+**Implemented enhancements:**
+
+- Add ability to run with one parameter instead -u -p [\#38](https://github.com/skywinder/Github-Changelog-Generator/issues/38)
+
+- Detailed output [\#33](https://github.com/skywinder/Github-Changelog-Generator/issues/33)
+
+**Fixed bugs:**
+
+- Docs lacking or basic behavior not as advertised [\#30](https://github.com/skywinder/Github-Changelog-Generator/issues/30)
+
+**Merged pull requests:**
+
+- Implement async fetching [\#39](https://github.com/skywinder/Github-Changelog-Generator/pull/39) ([skywinder](https://github.com/skywinder))
+
+- Fix crash when user is NULL [\#40](https://github.com/skywinder/Github-Changelog-Generator/pull/40) ([skywinder](https://github.com/skywinder))
+
+## [1.2.2](https://github.com/skywinder/Github-Changelog-Generator/tree/1.2.2) (2014-12-10)
+
+[Full Changelog](https://github.com/skywinder/Github-Changelog-Generator/compare/1.2.1...1.2.2)
+
+**Fixed bugs:**
+
+- Encapsulate \[ \> \* \_ \ \] signs in issues names [\#34](https://github.com/skywinder/Github-Changelog-Generator/issues/34)
+
+**Merged pull requests:**
+
+- Add a Bitdeli Badge to README [\#36](https://github.com/skywinder/Github-Changelog-Generator/pull/36) ([bitdeli-chef](https://github.com/bitdeli-chef))
+
+## [1.2.1](https://github.com/skywinder/Github-Changelog-Generator/tree/1.2.1) (2014-11-22)
+
+[Full Changelog](https://github.com/skywinder/Github-Changelog-Generator/compare/1.2.0...1.2.1)
+
+**Fixed bugs:**
+
+- Script fills changelog only for first 30 tags. [\#20](https://github.com/skywinder/Github-Changelog-Generator/issues/20)
+
+**Merged pull requests:**
+
+- Issues for last tag not in list [\#29](https://github.com/skywinder/Github-Changelog-Generator/pull/29) ([skywinder](https://github.com/skywinder))
+
+- Disable default --filter-pull-requests option. [\#28](https://github.com/skywinder/Github-Changelog-Generator/pull/28) ([skywinder](https://github.com/skywinder))
+
+## [1.2.0](https://github.com/skywinder/Github-Changelog-Generator/tree/1.2.0) (2014-11-19)
+
+[Full Changelog](https://github.com/skywinder/Github-Changelog-Generator/compare/1.1.4...1.2.0)
+
+**Merged pull requests:**
+
+- Add filter for pull-requests labels. \(option --filter-pull-requests\) [\#27](https://github.com/skywinder/Github-Changelog-Generator/pull/27) ([skywinder](https://github.com/skywinder))
+
+- Add ability to insert authors of pull-requests \(--\[no-\]author option\) [\#25](https://github.com/skywinder/Github-Changelog-Generator/pull/25) ([skywinder](https://github.com/skywinder))
+
+- Don't receive issues in case of --no-isses flag specied [\#24](https://github.com/skywinder/Github-Changelog-Generator/pull/24) ([skywinder](https://github.com/skywinder))
+
+## [1.1.4](https://github.com/skywinder/Github-Changelog-Generator/tree/1.1.4) (2014-11-18)
+
+[Full Changelog](https://github.com/skywinder/Github-Changelog-Generator/compare/1.1.2...1.1.4)
+
+**Implemented enhancements:**
+
+- Implement ability to retrieve GitHub token from ENV variable \(to not put it to script directly\) [\#19](https://github.com/skywinder/Github-Changelog-Generator/issues/19)
+
+**Merged pull requests:**
+
+- Sort tags by date [\#23](https://github.com/skywinder/Github-Changelog-Generator/pull/23) ([skywinder](https://github.com/skywinder))
+
+## [1.1.2](https://github.com/skywinder/Github-Changelog-Generator/tree/1.1.2) (2014-11-12)
+
+[Full Changelog](https://github.com/skywinder/Github-Changelog-Generator/compare/1.1.1...1.1.2)
+
+**Merged pull requests:**
+
+- Fix bug with dot signs in project name [\#18](https://github.com/skywinder/Github-Changelog-Generator/pull/18) ([skywinder](https://github.com/skywinder))
+
+- Fix bug with dot signs in user name [\#17](https://github.com/skywinder/Github-Changelog-Generator/pull/17) ([skywinder](https://github.com/skywinder))
+
+## [1.1.1](https://github.com/skywinder/Github-Changelog-Generator/tree/1.1.1) (2014-11-10)
+
+[Full Changelog](https://github.com/skywinder/Github-Changelog-Generator/compare/1.1.0...1.1.1)
+
+**Merged pull requests:**
+
+- Remove duplicates of issues and pull-requests with same number [\#15](https://github.com/skywinder/Github-Changelog-Generator/pull/15) ([skywinder](https://github.com/skywinder))
+
+- Sort issues by tags [\#14](https://github.com/skywinder/Github-Changelog-Generator/pull/14) ([skywinder](https://github.com/skywinder))
+
+- Add ability to add or exclude issues without any labels [\#13](https://github.com/skywinder/Github-Changelog-Generator/pull/13) ([skywinder](https://github.com/skywinder))
+
+## [1.1.0](https://github.com/skywinder/Github-Changelog-Generator/tree/1.1.0) (2014-11-10)
+
+[Full Changelog](https://github.com/skywinder/Github-Changelog-Generator/compare/1.0.1...1.1.0)
+
+**Implemented enhancements:**
+
+- Detect username and project form origin [\#11](https://github.com/skywinder/Github-Changelog-Generator/issues/11)
+
+**Fixed bugs:**
+
+- Bug with wrong credentials in 1.0.1 [\#12](https://github.com/skywinder/Github-Changelog-Generator/issues/12)
+
+- Markdown formating in the last line wrong [\#9](https://github.com/skywinder/Github-Changelog-Generator/issues/9)
+
+## [1.0.1](https://github.com/skywinder/Github-Changelog-Generator/tree/1.0.1) (2014-11-10)
+
+[Full Changelog](https://github.com/skywinder/Github-Changelog-Generator/compare/1.0.0...1.0.1)
+
+## [1.0.0](https://github.com/skywinder/Github-Changelog-Generator/tree/1.0.0) (2014-11-07)
+
+[Full Changelog](https://github.com/skywinder/Github-Changelog-Generator/compare/0.1.0...1.0.0)
+
+**Implemented enhancements:**
+
+- Add support for fixed issues and implemented enchanments. [\#6](https://github.com/skywinder/Github-Changelog-Generator/issues/6)
+
+- Implement option to specify output filename [\#4](https://github.com/skywinder/Github-Changelog-Generator/issues/4)
+
+**Fixed bugs:**
+
+- Last tag not appeared in changelog [\#5](https://github.com/skywinder/Github-Changelog-Generator/issues/5)
+
+**Merged pull requests:**
+
+- Implement support of different tags. [\#8](https://github.com/skywinder/Github-Changelog-Generator/pull/8) ([skywinder](https://github.com/skywinder))
+
+- Add support for issues in CHANGELOG [\#7](https://github.com/skywinder/Github-Changelog-Generator/pull/7) ([skywinder](https://github.com/skywinder))
+
+## [0.1.0](https://github.com/skywinder/Github-Changelog-Generator/tree/0.1.0) (2014-11-07)
+
+[Full Changelog](https://github.com/skywinder/Github-Changelog-Generator/compare/0.0.2...0.1.0)
+
+**Merged pull requests:**
+
+- Fix parsing date of pull request [\#3](https://github.com/skywinder/Github-Changelog-Generator/pull/3) ([skywinder](https://github.com/skywinder))
+
+- Add changelog generation for last tag [\#2](https://github.com/skywinder/Github-Changelog-Generator/pull/2) ([skywinder](https://github.com/skywinder))
+
+- Add option \(-o --output\) to specify name of the output file. [\#1](https://github.com/skywinder/Github-Changelog-Generator/pull/1) ([skywinder](https://github.com/skywinder))
+
+## [0.0.2](https://github.com/skywinder/Github-Changelog-Generator/tree/0.0.2) (2014-11-06)
+
+[Full Changelog](https://github.com/skywinder/Github-Changelog-Generator/compare/0.0.1...0.0.2)
+
+## [0.0.1](https://github.com/skywinder/Github-Changelog-Generator/tree/0.0.1) (2014-11-06)
 
 
 

--- a/lib/github_changelog_generator.rb
+++ b/lib/github_changelog_generator.rb
@@ -606,7 +606,7 @@ module GitHubChangelogGenerator
 
     def fetch_events_async(issues)
       i = 0
-      max_thread_number = 10
+      max_thread_number = 50
       threads = []
       issues.each_slice(max_thread_number) { |issues_slice|
         issues_slice.each { |issue|


### PR DESCRIPTION
Now changelog try to fetch all issues at once.
Each one in separate thread. So, I should limit number of concurrent threads.