### PR TITLE
Add --max-issues argument to limit requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Type `github_changelog_generator --help` for detailed usage.
         --[no-]compare-link          Include compare link between older version and newer version. Default is true
         --include-labels  x,y,z      Issues only with that labels will be included to changelog. Default is 'bug,enhancement'
         --exclude-labels  x,y,z      Issues with that labels will be always excluded from changelog. Default is 'duplicate,question,invalid,wontfix'
-        --max-issues [NUMBER]        Max number of issues to fetch from GitHub. Default is 500.
+        --max-issues [NUMBER]        Max number of issues to fetch from GitHub. Default is unlimited.
         --github-site [URL]          The Enterprise Github site on which your project is hosted.
         --github-api [URL]           The enterprise endpoint to use for your Github API.
     -v, --version                    Print version number
@@ -186,6 +186,15 @@ In the end:
 I think, that GitHub Releases is more for end-users.
 But `CHANGELOG.md` could stay in the repo for developers with detailed list of changes.
 And it's nothing bad to combine GitHub Releases and `CHANGELOG.md` file together in that manner.
+
+- ***I received a warning: GitHub API rate limit exceed, what does this mean?***
+
+GitHub [limits the number of API requests](https://developer.github.com/v3/#rate-limiting) you can make in an hour. You can make up to 5,000 requests per hour. For unauthenticated requests, the rate limit allows you to make up to 60 requests per hour. Unauthenticated requests are associated with your IP address, and not the user making requests.
+
+If you're seeing this warning:
+
+1. Make sure you're providing an OAuth token so you're not anonymously making requests. This will increase the number of requests from 60 to 5000 per hour.
+2. You probably have a large repo with lots of issues/PRs. You can use the `--max-issues NUM` argument to limit the number of issues that are pulled back. For example: `--max-issues 1000`
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Type `github_changelog_generator --help` for detailed usage.
         --[no-]compare-link          Include compare link between older version and newer version. Default is true
         --include-labels  x,y,z      Issues only with that labels will be included to changelog. Default is 'bug,enhancement'
         --exclude-labels  x,y,z      Issues with that labels will be always excluded from changelog. Default is 'duplicate,question,invalid,wontfix'
+        --max-issues [NUMBER]        Max number of issues to fetch from GitHub. Default is 500.
         --github-site [URL]          The Enterprise Github site on which your project is hosted.
         --github-api [URL]           The enterprise endpoint to use for your Github API.
     -v, --version                    Print version number

--- a/lib/github_changelog_generator.rb
+++ b/lib/github_changelog_generator.rb
@@ -596,6 +596,7 @@ begin
            page_i += PER_PAGE_NUMBER
            print "Fetching issues... #{page_i}/#{count_pages * PER_PAGE_NUMBER}\r"
            issues.concat(page)
+           break if issues.length >= @options[:max_issues]
          end
 rescue
          puts "Warning: GitHub API rate limit exceed (5000 per hour), change log may not contain some issues.".yellow

--- a/lib/github_changelog_generator/parser.rb
+++ b/lib/github_changelog_generator/parser.rb
@@ -24,7 +24,7 @@ module GitHubChangelogGenerator
           :enhancement_prefix => '**Implemented enhancements:**',
           :author => true,
           :filter_issues_by_milestone => true,
-          :max_issues => 500,
+          :max_issues => nil,
           :compare_link => true,
           :unreleased => true,
           :unreleased_label => 'Unreleased',
@@ -84,7 +84,7 @@ module GitHubChangelogGenerator
         opts.on('--exclude-labels  x,y,z', Array, 'Issues with that labels will be always excluded from changelog. Default is \'duplicate,question,invalid,wontfix\'') do |list|
           options[:exclude_labels] = list
         end
-        opts.on('--max-issues [NUMBER]', Integer, 'Max number of issues to fetch from GitHub. Default is 500') do |max|
+        opts.on('--max-issues [NUMBER]', Integer, 'Max number of issues to fetch from GitHub. Default is unlimited') do |max|
           options[:max_issues] = max
         end
         opts.on('--github-site [URL]', 'The Enterprise Github site on which your project is hosted.') do |last|

--- a/lib/github_changelog_generator/parser.rb
+++ b/lib/github_changelog_generator/parser.rb
@@ -24,6 +24,7 @@ module GitHubChangelogGenerator
           :enhancement_prefix => '**Implemented enhancements:**',
           :author => true,
           :filter_issues_by_milestone => true,
+          :max_issues => 500,
           :compare_link => true,
           :unreleased => true,
           :unreleased_label => 'Unreleased',
@@ -82,6 +83,9 @@ module GitHubChangelogGenerator
         end
         opts.on('--exclude-labels  x,y,z', Array, 'Issues with that labels will be always excluded from changelog. Default is \'duplicate,question,invalid,wontfix\'') do |list|
           options[:exclude_labels] = list
+        end
+        opts.on('--max-issues [NUMBER]', Integer, 'Max number of issues to fetch from GitHub. Default is 500') do |max|
+          options[:max_issues] = max
         end
         opts.on('--github-site [URL]', 'The Enterprise Github site on which your project is hosted.') do |last|
           options[:github_site] = last


### PR DESCRIPTION
This addresses issue #71 by providing a configurable limit on the number of issues to retrieve. By default this limits the number of issues to 500 which should help users stay under the GitHub API limit and keep change logs from growing ridiculous in size for older repos.