### PR TITLE
Relatively require github_changelog_generator library

### DIFF
--- a/bin/github_changelog_generator
+++ b/bin/github_changelog_generator
@@ -1,4 +1,4 @@
 #! /usr/bin/env ruby
 
-require 'github_changelog_generator'
+require_relative '../lib/github_changelog_generator'
 GitHubChangelogGenerator::ChangelogGenerator.new.compund_changelog


### PR DESCRIPTION
During development its possible for the gem installed version of github_changelog_generator lib to get required instead of the current development version of the library. This ensures that Ruby pulls in the correct version of the lib, specifically for development without breaking production builds.