### PR TITLE
Add future release option

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -7,7 +7,7 @@
 
 # Offense count: 21
 Metrics/AbcSize:
-  Max: 71
+  Enabled: false
 
 # Offense count: 2
 Metrics/BlockNesting:
@@ -25,7 +25,7 @@ Metrics/CyclomaticComplexity:
 # Offense count: 28
 # Configuration parameters: CountComments.
 Metrics/MethodLength:
-  Max: 118
+  Enabled: false
 
 # Offense count: 5
 Metrics/PerceivedComplexity:

--- a/README.md
+++ b/README.md
@@ -83,28 +83,29 @@ As output you will get `CHANGELOG.md` file with pretty *Markdown-formatted* chan
 Type `github_changelog_generator --help` for detailed usage.
 
     Usage: changelog_generator [options]
-    -u, --user [USER]                Username of the owner of target GitHub repo
-    -p, --project [PROJECT]          Name of project on GitHub
-    -t, --token [TOKEN]              To make more than 50 requests per hour your GitHub token required. You can generate it here: https://github.com/settings/tokens/new
-    -f, --date-format [FORMAT]       Date format. Default is %d/%m/%y
-    -o, --output [NAME]              Output file. Default is CHANGELOG.md
-        --[no-]verbose               Run verbosely. Default is true
-        --[no-]issues                Include closed issues to changelog. Default is true
-        --[no-]issues-wo-labels      Include closed issues without labels to changelog. Default is true
-        --[no-]pr-wo-labels          Include pull requests without labels to changelog. Default is true
-        --[no-]pull-requests         Include pull-requests to changelog. Default is true
-        --[no-]filter-by-milestone   Use milestone to detect when issue was resolved. Default is true
-        --[no-]author                Add author of pull-request in the end. Default is true
-        --unreleased-only            Generate log from unreleased closed issues only.
-        --[no-]unreleased            Add to log unreleased closed issues. Default is true
-        --[no-]compare-link          Include compare link between older version and newer version. Default is true
-        --include-labels  x,y,z      Issues only with that labels will be included to changelog. Default is 'bug,enhancement'
-        --exclude-labels  x,y,z      Issues with that labels will be always excluded from changelog. Default is 'duplicate,question,invalid,wontfix'
-        --max-issues [NUMBER]        Max number of issues to fetch from GitHub. Default is unlimited.
-        --github-site [URL]          The Enterprise Github site on which your project is hosted.
-        --github-api [URL]           The enterprise endpoint to use for your Github API.
-    -v, --version                    Print version number
-    -h, --help                       Displays Help
+    -u, --user [USER]                         Username of the owner of target GitHub repo
+    -p, --project [PROJECT]                   Name of project on GitHub
+    -t, --token [TOKEN]                       To make more than 50 requests per hour your GitHub token required. You can generate it here: https://github.com/settings/tokens/new
+    -f, --date-format [FORMAT]                Date format. Default is %d/%m/%y
+    -o, --output [NAME]                       Output file. Default is CHANGELOG.md
+        --[no-]verbose                        Run verbosely. Default is true
+        --[no-]issues                         Include closed issues to changelog. Default is true
+        --[no-]issues-wo-labels               Include closed issues without labels to changelog. Default is true
+        --[no-]pr-wo-labels                   Include pull requests without labels to changelog. Default is true
+        --[no-]pull-requests                  Include pull-requests to changelog. Default is true
+        --[no-]filter-by-milestone            Use milestone to detect when issue was resolved. Default is true
+        --[no-]author                         Add author of pull-request in the end. Default is true
+        --unreleased-only                     Generate log from unreleased closed issues only.
+        --[no-]unreleased                     Add to log unreleased closed issues. Default is true
+        --[no-]compare-link                   Include compare link between older version and newer version. Default is true
+        --include-labels  x,y,z               Issues only with that labels will be included to changelog. Default is 'bug,enhancement'
+        --exclude-labels  x,y,z               Issues with that labels will be always excluded from changelog. Default is 'duplicate,question,invalid,wontfix'
+        --max-issues [NUMBER]                 Max number of issues to fetch from GitHub. Default is unlimited.
+        --github-site [URL]                   The Enterprise Github site on which your project is hosted.
+        --github-api [URL]                    The enterprise endpoint to use for your Github API.
+        --future-release [RELEASE-VERSION]    Put the unreleased changes in the specified release number.
+    -v, --version                             Print version number
+    -h, --help                                Displays Help
 
 
 ### GitHub token

--- a/lib/github_changelog_generator.rb
+++ b/lib/github_changelog_generator.rb
@@ -388,8 +388,13 @@ module GitHubChangelogGenerator
     # @return [String] Ready and parsed section
     def create_log(pull_requests, issues, newer_tag, older_tag_name = nil)
       newer_tag_time = newer_tag.nil? ? Time.new : @fetcher.get_time_of_tag(newer_tag)
-      newer_tag_name = newer_tag.nil? ? @options[:unreleased_label] : newer_tag["name"]
-      newer_tag_link = newer_tag.nil? ? "HEAD" : newer_tag_name
+      if newer_tag.nil? && @options[:future_release]
+        newer_tag_name = @options[:future_release]
+        newer_tag_link = @options[:future_release]
+      else
+        newer_tag_name = newer_tag.nil? ? @options[:unreleased_label] : newer_tag["name"]
+        newer_tag_link = newer_tag.nil? ? "HEAD" : newer_tag_name
+      end
 
       github_site = options[:github_site] || "https://github.com"
       project_url = "#{github_site}/#{@options[:user]}/#{@options[:project]}"

--- a/lib/github_changelog_generator/parser.rb
+++ b/lib/github_changelog_generator/parser.rb
@@ -98,6 +98,9 @@ module GitHubChangelogGenerator
         opts.on("--simple-list", "Create simple list from issues and pull requests. Default is false.") do |v|
           options[:simple_list] = v
         end
+        opts.on("--future-release [RELEASE-VERSION]", "Put the unreleased changes in the specified release number.") do |future_release|
+          options[:future_release] = future_release
+        end
         opts.on("--[no-]verbose", "Run verbosely. Default is true") do |v|
           options[:verbose] = v
         end


### PR DESCRIPTION
Adds an option to put all unreleased changes into a future tag specified by parameter. Works like unreleased-label, but it also modifies the links to point to a [yet] inexistent release, soon to be created.
This fixes #230.