### PR TITLE
Wrap GitHub requests in function check_github_response

### DIFF
--- a/lib/CHANGELOG.md
+++ b/lib/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 **Merged pull requests:**
 
+- this pr will be closed and shouldn't appear in changelog [\#7](https://github.com/skywinder/changelog_test/pull/7) ([skywinder](https://github.com/skywinder))
+
 - This PR SHOULD NOT appear in change log! [\#6](https://github.com/skywinder/changelog_test/pull/6) ([skywinder](https://github.com/skywinder))
 
 - Add automatically generated change log file. [\#5](https://github.com/skywinder/changelog_test/pull/5) ([skywinder](https://github.com/skywinder))

--- a/lib/github_changelog_generator/fetcher.rb
+++ b/lib/github_changelog_generator/fetcher.rb
@@ -9,8 +9,10 @@ module GitHubChangelogGenerator
   class Fetcher
     PER_PAGE_NUMBER = 30
     CHANGELOG_GITHUB_TOKEN = "CHANGELOG_GITHUB_TOKEN"
-    GH_RATE_LIMIT_EXCEEDED_MSG = "Warning: GitHub API rate limit (5000 per hour) exceeded, change log may be " \
-        "missing some issues. You can limit the number of issues fetched using the `--max-issues NUM` argument."
+    GH_RATE_LIMIT_EXCEEDED_MSG = "Warning: Can't finish operation: GitHub API rate limit exceeded, change log may be " \
+    "missing some issues. You can limit the number of issues fetched using the `--max-issues NUM` argument."
+    NO_TOKEN_PROVIDED = "Warning: No token provided (-t option) and variable $CHANGELOG_GITHUB_TOKEN was not found. " \
+    "This script can make only 50 requests to GitHub API per hour without token!"
 
     def initialize(options = {})
       @options = options
@@ -29,11 +31,7 @@ module GitHubChangelogGenerator
       github_options[:endpoint] = options[:github_endpoint] unless options[:github_endpoint].nil?
       github_options[:site] = options[:github_endpoint] unless options[:github_site].nil?
 
-      begin
-        @github = Github.new github_options
-      rescue
-        @logger.warn GH_RATE_LIMIT_EXCEEDED_MSG.yellow
-      end
+      @github = check_github_response{Github.new github_options}
     end
 
     # Returns GitHub token. First try to use variable, provided by --token option,
@@ -44,8 +42,7 @@ module GitHubChangelogGenerator
       env_var = @options[:token] ? @options[:token] : (ENV.fetch CHANGELOG_GITHUB_TOKEN, nil)
 
       unless env_var
-        @logger.warn "Warning: No token provided (-t option) and variable $CHANGELOG_GITHUB_TOKEN was not found.".yellow
-        @logger.warn "This script can make only 50 requests to GitHub API per hour without token!".yellow
+        @logger.warn NO_TOKEN_PROVIDED.yellow
       end
 
       env_var
@@ -60,19 +57,22 @@ module GitHubChangelogGenerator
 
       tags = []
 
-      begin
-        github_fetch_tags(tags)
-      rescue Github::Error::Unauthorized => e
-        @logger.error e.body.red
-        @logger.error "Error: wrong github token provided".red
-      rescue Github::Error::Forbidden => e
-        @logger.warn e.body.red
-        unless @options[:token].nil?
-          @logger.warn GH_RATE_LIMIT_EXCEEDED_MSG.yellow
-        end
-      end
+      check_github_response { github_fetch_tags(tags) }
 
       tags
+    end
+
+    def check_github_response
+      begin
+        value = yield
+      rescue Github::Error::Unauthorized => e
+        @logger.error e.body.red
+        abort "Error: wrong GitHub token"
+      rescue Github::Error::Forbidden => e
+        @logger.warn e.body.red
+        @logger.warn GH_RATE_LIMIT_EXCEEDED_MSG.yellow
+      end
+      value
     end
 
     def github_fetch_tags(tags)
@@ -118,8 +118,6 @@ Make sure, that you push tags to remote repo via 'git push --tags'".yellow
           break if @options[:max_issues] && issues.length >= @options[:max_issues]
         end
       rescue
-        puts e.message
-        puts e.backtrace.inspect
         @logger.warn GH_RATE_LIMIT_EXCEEDED_MSG.yellow
       end
 

--- a/lib/github_changelog_generator/fetcher.rb
+++ b/lib/github_changelog_generator/fetcher.rb
@@ -26,12 +26,12 @@ module GitHubChangelogGenerator
       @project = @options[:project]
       @github_token = fetch_github_token
       @tag_times_hash = {}
-      github_options = {per_page: PER_PAGE_NUMBER}
+      github_options = { per_page: PER_PAGE_NUMBER }
       github_options[:oauth_token] = @github_token unless @github_token.nil?
       github_options[:endpoint] = options[:github_endpoint] unless options[:github_endpoint].nil?
       github_options[:site] = options[:github_endpoint] unless options[:github_site].nil?
 
-      @github = check_github_response{Github.new github_options}
+      @github = check_github_response { Github.new github_options }
     end
 
     # Returns GitHub token. First try to use variable, provided by --token option,

--- a/spec/unit/fetcher_spec.rb
+++ b/spec/unit/fetcher_spec.rb
@@ -1,5 +1,16 @@
+VALID_TOKEN = "0123456789abcdef"
+INVALID_TOKEN = "0000000000000000"
+
+DEFAULT_OPTIONS = { user: "skywinder",
+                    project: "changelog_test" }
+
+def options_with_invalid_token
+  options = DEFAULT_OPTIONS
+  options[:token] = INVALID_TOKEN
+  options
+end
+
 describe GitHubChangelogGenerator::Fetcher do
-  VALID_TOKEN = "0123456789abcdef"
   before(:all) do
     @fetcher = GitHubChangelogGenerator::Fetcher.new
   end
@@ -31,6 +42,18 @@ describe GitHubChangelogGenerator::Fetcher do
       end
       subject { @fetcher.fetch_github_token }
       it { is_expected.to eq(VALID_TOKEN) }
+    end
+  end
+
+  describe "#github_fetch_tags" do
+    context "when wrong token provided" do
+      before do
+        options = options_with_invalid_token
+        @fetcher = GitHubChangelogGenerator::Fetcher.new(options)
+      end
+      it "should raise Unauthorized error" do
+        expect { @fetcher.github_fetch_tags [] }.to raise_error Github::Error::Unauthorized
+      end
     end
   end
 end


### PR DESCRIPTION
All `begin-rescue-end` blocks for  `@github` parameter in `fetcher.rb`, that check that github fetch completed without errors. moved to (`check_github_response` function). 
Not I have to call `check_github_response` before all `@github` calls.