### PR TITLE
Add release_url option

### DIFF
--- a/lib/github_changelog_generator/generator/generator_generation.rb
+++ b/lib/github_changelog_generator/generator/generator_generation.rb
@@ -76,10 +76,15 @@ module GitHubChangelogGenerator
       time_string = newer_tag_time.strftime @options[:date_format]
 
       # Generate tag name and link
-      if newer_tag_name.equal? @options[:unreleased_label]
-        log += "## [#{newer_tag_name}](#{project_url}/tree/#{newer_tag_link})\n\n"
+      if @options[:release_url]
+        release_url = format(@options[:release_url], newer_tag_link)
       else
-        log += "## [#{newer_tag_name}](#{project_url}/tree/#{newer_tag_link}) (#{time_string})\n"
+        release_url = "#{project_url}/tree/#{newer_tag_link}"
+      end
+      if newer_tag_name.equal? @options[:unreleased_label]
+        log += "## [#{newer_tag_name}](#{release_url})\n\n"
+      else
+        log += "## [#{newer_tag_name}](#{release_url}) (#{time_string})\n"
       end
 
       if @options[:compare_link] && older_tag_link

--- a/lib/github_changelog_generator/parser.rb
+++ b/lib/github_changelog_generator/parser.rb
@@ -119,6 +119,9 @@ module GitHubChangelogGenerator
         opts.on("--max-issues [NUMBER]", Integer, "Max number of issues to fetch from GitHub. Default is unlimited") do |max|
           options[:max_issues] = max
         end
+        opts.on("--release-url [URL]", "The URL to point to for release links, in printf format (with the tag as variable).") do |url|
+          options[:release_url] = url
+        end
         opts.on("--github-site [URL]", "The Enterprise Github site on which your project is hosted.") do |last|
           options[:github_site] = last
         end


### PR DESCRIPTION
When linking to releases, maintainers might prefer to link to a package repository/forge instead of the GitHub tree. This PR adds a `release_url` option which does just that. Example usage, for a Puppet module:

```
github_changelog_generator --release-url "https://forge.puppetlabs.com/camptocamp/systemd/%s"
```

Obviously, it means the user is responsible for forging the proper URL, since it would be very tricky to teach github-changelog-generator to parse gemspecs, Puppet's metadata.json and other formats to retrieve it.