### PR TITLE
Fix comparing pull requests between tags by merged_at field 

### DIFF
--- a/lib/github_changelog_generator/generator/generator_generation.rb
+++ b/lib/github_changelog_generator/generator/generator_generation.rb
@@ -115,7 +115,7 @@ module GitHubChangelogGenerator
     #
     # @return [Array] filtered issues and pull requests
     def filter_issues_for_tags(newer_tag, older_tag)
-      filtered_pull_requests = delete_by_time(@pull_requests, :actual_date, older_tag, newer_tag)
+      filtered_pull_requests = delete_by_time(@pull_requests, :merged_at, older_tag, newer_tag)
       filtered_issues = delete_by_time(@issues, :actual_date, older_tag, newer_tag)
 
       newer_tag_name = newer_tag.nil? ? nil : newer_tag["name"]


### PR DESCRIPTION
So far they were compared by actual_date field, which caused some PRs not to be listed in the changelog.