### PR TITLE
Honor labels for Pull Requests

### DIFF
--- a/lib/github_changelog_generator/generator/generator.rb
+++ b/lib/github_changelog_generator/generator/generator.rb
@@ -66,7 +66,7 @@ module GitHubChangelogGenerator
 
       if @options[:issues]
         # Generate issues:
-        log += issues_to_log(issues)
+        log += issues_to_log(issues, pull_requests)
       end
 
       if @options[:pulls]
@@ -77,13 +77,14 @@ module GitHubChangelogGenerator
       log
     end
 
-    # Generate ready-to-paste log from list of issues.
+    # Generate ready-to-paste log from list of issues and pull requests.
     #
     # @param [Array] issues
+    # @param [Array] pull_requests
     # @return [String] generated log for issues
-    def issues_to_log(issues)
+    def issues_to_log(issues, pull_requests)
       log = ""
-      bugs_a, enhancement_a, issues_a = parse_by_sections(issues)
+      bugs_a, enhancement_a, issues_a = parse_by_sections(issues, pull_requests)
 
       log += generate_sub_section(enhancement_a, @options[:enhancement_prefix])
       log += generate_sub_section(bugs_a, @options[:bug_prefix])
@@ -95,8 +96,9 @@ module GitHubChangelogGenerator
     # (bugs, features, or just closed issues) by labels
     #
     # @param [Array] issues
+    # @param [Array] pull_requests
     # @return [Array] tuple of filtered arrays: (Bugs, Enhancements Issues)
-    def parse_by_sections(issues)
+    def parse_by_sections(issues, pull_requests)
       issues_a = []
       enhancement_a = []
       bugs_a = []
@@ -117,6 +119,24 @@ module GitHubChangelogGenerator
         end
         issues_a.push dict unless added
       end
+
+      pull_requests.each do |dict|
+        added = false
+        dict.labels.each do |label|
+          if @options[:bug_labels].include? label.name
+            bugs_a.push dict
+            added = true
+            next
+          end
+          if @options[:enhancement_labels].include? label.name
+            enhancement_a.push dict
+            added = true
+            next
+          end
+        end
+        pull_requests.delete(dict) if added
+      end
+
       [bugs_a, enhancement_a, issues_a]
     end
   end


### PR DESCRIPTION
Labels are only used to organize issues in the Changelog, not Pull Requests.

I don't think users of a project really cares about whether features were implemented through Pull Requests or directly by a maintainer. If a Pull Request is marked as an enhancement or a bug, it seems logic that it should be listed as such, not as a generic pull request.

