### PR TITLE
Use since_tag as default for older_tag

### DIFF
--- a/lib/github_changelog_generator/generator/generator_generation.rb
+++ b/lib/github_changelog_generator/generator/generator_generation.rb
@@ -103,7 +103,7 @@ module GitHubChangelogGenerator
     def generate_log_between_tags(older_tag, newer_tag)
       filtered_issues, filtered_pull_requests = filter_issues_for_tags(newer_tag, older_tag)
 
-      older_tag_name = older_tag.nil? ? nil : older_tag["name"]
+      older_tag_name = older_tag.nil? ? detect_since_tag : older_tag["name"]
 
       if newer_tag.nil? && filtered_issues.empty? && filtered_pull_requests.empty?
         # do not generate empty unreleased section

--- a/lib/github_changelog_generator/generator/generator_tags.rb
+++ b/lib/github_changelog_generator/generator/generator_tags.rb
@@ -54,11 +54,13 @@ module GitHubChangelogGenerator
 
     # @return [Object] try to find newest tag using #Reader and :base option if specified otherwise returns nil
     def detect_since_tag
-      if @options[:base] && File.file?(@options[:base])
+      @since_tag ||= @options[:since_tag]
+      if @since_tag.nil? && @options[:base] && File.file?(@options[:base])
         reader = GitHubChangelogGenerator::Reader.new
         content = reader.read(@options[:base])
-        return content[0]["version"] if content
+        @since_tag = content[0]["version"] if content
       end
+      @since_tag
     end
 
     # Return tags after filtering tags in lists provided by option: --between-tags & --exclude-tags
@@ -74,8 +76,7 @@ module GitHubChangelogGenerator
     # @return [Array] filtered tags according :since_tag option
     def filter_since_tag(all_tags)
       filtered_tags = all_tags
-      tag = @options[:since_tag]
-      tag ||= detect_since_tag
+      tag = detect_since_tag
       if tag
         if all_tags.map(&:name).include? tag
           idx = all_tags.index { |t| t.name == tag }


### PR DESCRIPTION
When using `since_tag`, the full changelog link is not generated for the first entry.

This commit makes `older_tag` default to `since_tag` when `nil` to fix this.