### PR TITLE
Rake task: Be able to set false value in config

### DIFF
--- a/lib/github_changelog_generator/task.rb
+++ b/lib/github_changelog_generator/task.rb
@@ -51,7 +51,7 @@ module GitHubChangelogGenerator
 
         OPTIONS.each do |o|
           v = instance_variable_get("@#{o}")
-          options[o.to_sym] = v if v
+          options[o.to_sym] = v unless v.nil?
         end
 
         generator = Generator.new options


### PR DESCRIPTION
I wanted to disable the author information from the changelog, and noted that I couldn't. 

Instead of checking for falsy config values from the Rake task's configuration block, let's check-and-skip  nil values.

Example of what works, now:

```ruby
GitHubChangelogGenerator::RakeTask.new(:changelog) do |config|
  config.author = false
end
```