### PR TITLE
Rubocop: less complex methods in parser.rb

### DIFF
--- a/lib/github_changelog_generator/parser.rb
+++ b/lib/github_changelog_generator/parser.rb
@@ -7,7 +7,7 @@ module GitHubChangelogGenerator
   class Parser
     # parse options with optparse
     def self.parse_options
-      options = get_default_options
+      options = default_options
 
       ParserFile.new(options).parse!
 
@@ -159,8 +159,8 @@ module GitHubChangelogGenerator
     end
 
     # just get default options
-    def self.get_default_options
-      options = {
+    def self.default_options
+      {
         tag1: nil,
         tag2: nil,
         date_format: "%Y-%m-%d",
@@ -188,8 +188,6 @@ module GitHubChangelogGenerator
         enhancement_prefix: "**Implemented enhancements:**",
         git_remote: "origin"
       }
-
-      options
     end
 
     def self.user_and_project_from_git

--- a/lib/github_changelog_generator/task.rb
+++ b/lib/github_changelog_generator/task.rb
@@ -43,11 +43,9 @@ module GitHubChangelogGenerator
 
       task @name do
         # mimick parse_options
-        options = Parser.get_default_options
+        options = Parser.default_options
 
-        if options[:user].nil? || options[:project].nil?
-          Parser.detect_user_and_project(options)
-        end
+        Parser.user_and_project_from_git(options)
 
         OPTIONS.each do |o|
           v = instance_variable_get("@#{o}")

--- a/spec/unit/parse_file_spec.rb
+++ b/spec/unit/parse_file_spec.rb
@@ -24,7 +24,7 @@ describe GitHubChangelogGenerator::ParserFile do
     end
 
     context "when override default values" do
-      let(:default_options) { GitHubChangelogGenerator::Parser.get_default_options }
+      let(:default_options) { GitHubChangelogGenerator::Parser.default_options }
       let(:options) { { params_file: "spec/files/github_changelog_params_override" }.merge(default_options) }
       let(:options_before_change) { options.dup }
       let(:parse) { GitHubChangelogGenerator::ParserFile.new(options) }


### PR DESCRIPTION
- Changed one thing: failed return value on printing the banner when
    no user or project was found.
- Renamed a `get_` method to fix a Rubocop TODO