### PR TITLE
[refactor] Reader: positive Boolean; unused #map

### DIFF
--- a/lib/github_changelog_generator/reader.rb
+++ b/lib/github_changelog_generator/reader.rb
@@ -53,10 +53,10 @@ module GitHubChangelogGenerator
 
       @heading_structures.each do |regexp|
         matches = Regexp.new(regexp).match(heading)
-        captures.merge!(Hash[matches.names.map.zip(matches.captures)]) unless matches.nil?
-
-        # Try Regular Expressions until you find one that delivers results
-        break unless matches.nil?
+        if matches
+          captures.merge!(Hash[matches.names.zip(matches.captures)])
+          break
+        end
       end
 
       captures


### PR DESCRIPTION
Logic is difficult to read quickly. To help the reader of the Reader class, this PR turns around two `unless` to an `if`.

Now, the code reads well enough to lose the explanatory code comment.