### PR TITLE
Use GitHub tags to reference GitHub users

### DIFF
--- a/lib/github_changelog_generator/generator/generator_generation.rb
+++ b/lib/github_changelog_generator/generator/generator_generation.rb
@@ -172,7 +172,11 @@ module GitHubChangelogGenerator
           if issue.user.nil?
             title_with_number += " ({Null user})"
           else
-            title_with_number += " ([#{issue.user.login}](#{issue.user.html_url}))"
+            if issue.user.html_url.exclude? "github.com"
+              title_with_number += " ([#{issue.user.login}](#{issue.user.html_url}))"
+            else
+              title_with_number += " (@#{issue.user.login})"
+            end
           end
         end
       end

--- a/lib/github_changelog_generator/generator/generator_generation.rb
+++ b/lib/github_changelog_generator/generator/generator_generation.rb
@@ -168,15 +168,15 @@ module GitHubChangelogGenerator
       title_with_number = "#{encapsulated_title} [\\##{issue[:number]}](#{issue.html_url})"
       issue_line_with_user(title_with_number, issue)
     end
-    
+
     private
-    
+
     def issue_line_with_user(line, issue)
       return line if !@options[:author] || issue.pull_request.nil?
-      
+
       user = issue.user
       return "#{line} ({Null user})" unless user
-      
+
       if user.html_url.include?("github.com")
         "#{line} (@#{user.login})"
       else

--- a/lib/github_changelog_generator/generator/generator_generation.rb
+++ b/lib/github_changelog_generator/generator/generator_generation.rb
@@ -158,7 +158,7 @@ module GitHubChangelogGenerator
     # Parse issue and generate single line formatted issue line.
     #
     # Example output:
-    # - Add coveralls integration [\#223](https://github.com/skywinder/github-changelog-generator/pull/223) ([skywinder](https://github.com/skywinder))
+    # - Add coveralls integration [\#223](https://github.com/skywinder/github-changelog-generator/pull/223) (@skywinder)
     #
     # @param [Hash] issue Fetched issue from GitHub
     # @return [String] Markdown-formatted single issue
@@ -166,21 +166,22 @@ module GitHubChangelogGenerator
       encapsulated_title = encapsulate_string issue[:title]
 
       title_with_number = "#{encapsulated_title} [\\##{issue[:number]}](#{issue.html_url})"
-
-      unless issue.pull_request.nil?
-        if @options[:author]
-          if issue.user.nil?
-            title_with_number += " ({Null user})"
-          else
-            if issue.user.html_url.exclude? "github.com"
-              title_with_number += " ([#{issue.user.login}](#{issue.user.html_url}))"
-            else
-              title_with_number += " (@#{issue.user.login})"
-            end
-          end
-        end
+      issue_line_with_user(title_with_number, issue)
+    end
+    
+    private
+    
+    def issue_line_with_user(line, issue)
+      return line if !@options[:author] || issue.pull_request.nil?
+      
+      user = issue.user
+      return "#{line} ({Null user})" unless user
+      
+      if user.html_url.include?("github.com")
+        "#{line} (@#{user.login})"
+      else
+        "#{line} ([#{user.login}](#{user.html_url}))"
       end
-      title_with_number
     end
   end
 end

--- a/lib/github_changelog_generator/parser.rb
+++ b/lib/github_changelog_generator/parser.rb
@@ -89,6 +89,9 @@ module GitHubChangelogGenerator
         opts.on("--[no-]author", "Add author of pull-request in the end. Default is true") do |author|
           options[:author] = author
         end
+        opts.on("--usernames-as-github-logins", "Use GitHub tags instead of links for the author of an issue or pull-request.") do |v|
+          options[:usernames_as_github_logins] = v
+        end
         opts.on("--unreleased-only", "Generate log from unreleased closed issues only.") do |v|
           options[:unreleased_only] = v
         end


### PR DESCRIPTION
This will use @tags to notify the contributor that their contribution is in the changelog.

As discussed in https://github.com/github/linguist/pull/2698#issuecomment-150887871