### PR TITLE
Fixes #280 Add release-branch option to filter the Pull Requests

### DIFF
--- a/lib/github_changelog_generator/fetcher.rb
+++ b/lib/github_changelog_generator/fetcher.rb
@@ -15,10 +15,10 @@ module GitHubChangelogGenerator
 
     def initialize(options = {})
       @options = options || {}
+      @user = @options[:user]
+      @project = @options[:project]
       @github_token = fetch_github_token
       @github_options = { per_page: PER_PAGE_NUMBER }
-      @github_options[:user] = @options[:user]
-      @github_options[:repo] = @options[:project]
       @github_options[:oauth_token] = @github_token unless @github_token.nil?
       @github_options[:endpoint] = @options[:github_endpoint] unless @options[:github_endpoint].nil?
       @github_options[:site] = @options[:github_endpoint] unless @options[:github_site].nil?

--- a/lib/github_changelog_generator/fetcher.rb
+++ b/lib/github_changelog_generator/fetcher.rb
@@ -22,6 +22,7 @@ module GitHubChangelogGenerator
       github_options[:oauth_token] = @github_token unless @github_token.nil?
       github_options[:endpoint] = @options[:github_endpoint] unless @options[:github_endpoint].nil?
       github_options[:site] = @options[:github_endpoint] unless @options[:github_site].nil?
+      @release_branch = @options[:release_branch] unless @options[:release_branch].nil?
 
       @github = check_github_response { Github.new github_options }
     end
@@ -123,7 +124,11 @@ Make sure, that you push tags to remote repo via 'git push --tags'".yellow
     def fetch_closed_pull_requests
       pull_requests = []
       begin
-        response = @github.pull_requests.list @options[:user], @options[:project], state: "closed"
+        if @options[:release_branch].nil?
+          response = @github.pull_requests.list @options[:user], @options[:project], state: "closed"
+        else
+          response = @github.pull_requests.list @options[:user], @options[:project], state: "closed", base: @options[:release_branch]
+        end
         page_i = 0
         count_pages = response.count_pages
         response.each_page do |page|

--- a/lib/github_changelog_generator/fetcher.rb
+++ b/lib/github_changelog_generator/fetcher.rb
@@ -15,14 +15,13 @@ module GitHubChangelogGenerator
 
     def initialize(options = {})
       @options = options || {}
-      @user = @options[:user]
-      @project = @options[:project]
       @github_token = fetch_github_token
       github_options = { per_page: PER_PAGE_NUMBER }
+      github_options[:user] = @options[:user]
+      github_options[:repo] = @options[:project]
       github_options[:oauth_token] = @github_token unless @github_token.nil?
       github_options[:endpoint] = @options[:github_endpoint] unless @options[:github_endpoint].nil?
       github_options[:site] = @options[:github_endpoint] unless @options[:github_site].nil?
-      @release_branch = @options[:release_branch] unless @options[:release_branch].nil?
 
       @github = check_github_response { Github.new github_options }
     end
@@ -66,7 +65,7 @@ module GitHubChangelogGenerator
     # @return [Array] array of tags in repo
     def github_fetch_tags
       tags = []
-      response = @github.repos.tags @options[:user], @options[:project]
+      response = @github.repos.tags
       page_i = 0
       count_pages = response.count_pages
       response.each_page do |page|
@@ -125,7 +124,9 @@ Make sure, that you push tags to remote repo via 'git push --tags'".yellow
       pull_requests = []
       begin
         if @options[:release_branch].nil?
-          response = @github.pull_requests.list @options[:user], @options[:project], state: "closed"
+          response = @github.pull_requests.list @options[:user],
+                                                @options[:project],
+                                                state: "closed"
         else
           response = @github.pull_requests.list @options[:user], @options[:project], state: "closed", base: @options[:release_branch]
         end

--- a/lib/github_changelog_generator/fetcher.rb
+++ b/lib/github_changelog_generator/fetcher.rb
@@ -92,9 +92,7 @@ Make sure, that you push tags to remote repo via 'git push --tags'".yellow
       issues = []
 
       begin
-        response = @github.issues.list user: @options[:user],
-                                       repo: @options[:project],
-                                       state: "closed",
+        response = @github.issues.list state: "closed",
                                        filter: "all",
                                        labels: nil
         page_i = 0
@@ -124,11 +122,10 @@ Make sure, that you push tags to remote repo via 'git push --tags'".yellow
       pull_requests = []
       begin
         if @options[:release_branch].nil?
-          response = @github.pull_requests.list @options[:user],
-                                                @options[:project],
-                                                state: "closed"
+          response = @github.pull_requests.list state: "closed"
         else
-          response = @github.pull_requests.list @options[:user], @options[:project], state: "closed", base: @options[:release_branch]
+          response = @github.pull_requests.list state: "closed",
+                                                base: @options[:release_branch]
         end
         page_i = 0
         count_pages = response.count_pages
@@ -169,9 +166,7 @@ Make sure, that you push tags to remote repo via 'git push --tags'".yellow
         issues_slice.each do |issue|
           threads << Thread.new do
             begin
-              response = @github.issues.events.list user: @options[:user],
-                                                    repo: @options[:project],
-                                                    issue_number: issue["number"]
+              response = @github.issues.events.list issue_number: issue["number"]
               issue[:events] = []
               response.each_page do |page|
                 issue[:events].concat(page)
@@ -199,9 +194,7 @@ Make sure, that you push tags to remote repo via 'git push --tags'".yellow
     # @return [Time] time of specified tag
     def fetch_date_of_tag(tag)
       begin
-        commit_data = @github.git_data.commits.get @options[:user],
-                                                   @options[:project],
-                                                   tag["commit"]["sha"]
+        commit_data = @github.git_data.commits.get tag["commit"]["sha"]
       rescue
         Helper.log.warn GH_RATE_LIMIT_EXCEEDED_MSG.yellow
       end
@@ -212,7 +205,7 @@ Make sure, that you push tags to remote repo via 'git push --tags'".yellow
     # Fetch commit for specified event
     # @return [Hash]
     def fetch_commit(event)
-      @github.git_data.commits.get @options[:user], @options[:project], event[:commit_id]
+      @github.git_data.commits.get event[:commit_id]
     end
   end
 end

--- a/lib/github_changelog_generator/fetcher.rb
+++ b/lib/github_changelog_generator/fetcher.rb
@@ -201,7 +201,6 @@ Make sure, that you push tags to remote repo via 'git push --tags'".yellow
     # @param [Hash] tag
     # @return [Time] time of specified tag
     def fetch_date_of_tag(tag)
-      puts @github_options
       begin
         commit_data = @github.git_data.commits.get @options[:user],
                                                    @options[:project],

--- a/lib/github_changelog_generator/generator/generator_processor.rb
+++ b/lib/github_changelog_generator/generator/generator_processor.rb
@@ -178,7 +178,7 @@ module GitHubChangelogGenerator
         fetched_pr = closed_pull_requests.find do |fpr|
           fpr.number == pr.number
         end
-        unless fetched_pr.nil?
+        if fetched_pr
           pr[:merged_at] = fetched_pr[:merged_at]
           closed_pull_requests.delete(fetched_pr)
         end

--- a/lib/github_changelog_generator/generator/generator_processor.rb
+++ b/lib/github_changelog_generator/generator/generator_processor.rb
@@ -178,8 +178,10 @@ module GitHubChangelogGenerator
         fetched_pr = closed_pull_requests.find do |fpr|
           fpr.number == pr.number
         end
-        pr[:merged_at] = fetched_pr[:merged_at]
-        closed_pull_requests.delete(fetched_pr)
+        unless fetched_pr.nil?
+          pr[:merged_at] = fetched_pr[:merged_at]
+          closed_pull_requests.delete(fetched_pr)
+        end
       end
 
       pull_requests.select! do |pr|

--- a/lib/github_changelog_generator/parser.rb
+++ b/lib/github_changelog_generator/parser.rb
@@ -143,6 +143,9 @@ module GitHubChangelogGenerator
         opts.on("--future-release [RELEASE-VERSION]", "Put the unreleased changes in the specified release number.") do |future_release|
           options[:future_release] = future_release
         end
+        opts.on("--release-branch [RELEASE-BRANCH]", "Limit pull requests to the release branch, such as master or release") do |release_branch|
+          options[:release_branch] = release_branch
+        end
         opts.on("--[no-]verbose", "Run verbosely. Default is true") do |v|
           options[:verbose] = v
         end

--- a/lib/github_changelog_generator/parser.rb
+++ b/lib/github_changelog_generator/parser.rb
@@ -190,7 +190,7 @@ module GitHubChangelogGenerator
       }
     end
 
-    def self.user_and_project_from_git
+    def self.user_and_project_from_git(options)
       if options[:user].nil? || options[:project].nil?
         detect_user_and_project(options, ARGV[0], ARGV[1])
       end

--- a/lib/github_changelog_generator/task.rb
+++ b/lib/github_changelog_generator/task.rb
@@ -16,7 +16,8 @@ module GitHubChangelogGenerator
                   bug_labels enhancement_labels
                   between_tags exclude_tags since_tag max_issues
                   github_site github_endpoint simple_list
-                  future_release verbose release_url base )
+                  future_release release_branch verbose release_url 
+                  base )
 
     OPTIONS.each do |o|
       attr_accessor o.to_sym

--- a/lib/github_changelog_generator/task.rb
+++ b/lib/github_changelog_generator/task.rb
@@ -16,7 +16,7 @@ module GitHubChangelogGenerator
                   bug_labels enhancement_labels
                   between_tags exclude_tags since_tag max_issues
                   github_site github_endpoint simple_list
-                  future_release release_branch verbose release_url 
+                  future_release release_branch verbose release_url
                   base )
 
     OPTIONS.each do |o|


### PR DESCRIPTION
This adds the ability to pass a Base through to the github pull requests API, thereby restricting the Pull Requests returned to just the branch you are interested in. This applies to any project with more than one branch receiving Pull requests. i.e. Development and Release, Master and Feature.

And just taught myself the Ruby I needed for this so feel free to fix it.
Fixes #280