### PR TITLE
Update bundler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: ruby
-before_install: gem update --system
+before_install: 
+- gem update --system
+- gem install bundler
 rvm:
 - 2.1.0
 script:


### PR DESCRIPTION
Standard Bundler in Travis is old and causes build issues, well that is the theory. This will update bundler.

https://github.com/travis-ci/travis-ci/issues/3531