### PR TITLE
Parser: avoid Ruby exit, to make Rake tasks work

### DIFF
--- a/github_changelog_generator.gemspec
+++ b/github_changelog_generator.gemspec
@@ -9,14 +9,14 @@ Gem::Specification.new do |spec|
   spec.version            = GitHubChangelogGenerator::VERSION
   spec.default_executable = "github_changelog_generator"
 
-  spec.required_ruby_version     = ">= 1.9.3"
+  spec.required_ruby_version = ">= 1.9.3"
   spec.authors = ["Petr Korolev"]
   spec.email = "sky4winder+github_changelog_generator@gmail.com"
   spec.date = `date +"%Y-%m-%d"`.strip!
   spec.summary = "Script, that automatically generate changelog from your tags, issues, labels and pull requests."
   spec.description = "Changelog generation has never been so easy. Fully automate changelog generation - this gem generate change log file based on tags, issues and merged pull requests from Github issue tracker."
   spec.homepage = "https://github.com/skywinder/Github-Changelog-Generator"
-  spec.license       = "MIT"
+  spec.license = "MIT"
 
   spec.files = `git ls-files -z`.split("\x0")
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/lib/github_changelog_generator/parser.rb
+++ b/lib/github_changelog_generator/parser.rb
@@ -217,7 +217,7 @@ module GitHubChangelogGenerator
     #
     # @param [String] output of git remote command
     # @return [Array] user and project
-    def self.user_project_from_option(arg0, arg1, github_site = nil)
+    def self.user_project_from_option(arg0, arg1, github_site)
       user = nil
       project = nil
       github_site ||= "github.com"
@@ -230,10 +230,10 @@ module GitHubChangelogGenerator
           param = match[2].nil?
         rescue
           puts "Can't detect user and name from first parameter: '#{arg0}' -> exit'"
-          exit
+          return
         end
         if param
-          exit
+          return
         else
           user = match[1]
           project = match[2]
@@ -275,10 +275,5 @@ module GitHubChangelogGenerator
 
       [user, project]
     end
-  end
-
-  if __FILE__ == $PROGRAM_NAME
-    remote = "invalid reference to project"
-    p user_project_from_option(ARGV[0], ARGV[1], remote)
   end
 end

--- a/spec/unit/parser_spec.rb
+++ b/spec/unit/parser_spec.rb
@@ -28,16 +28,16 @@ describe GitHubChangelogGenerator::Parser do
   end
   describe ".user_project_from_option" do
     context "when option is invalid" do
-      it("should exit") { expect { GitHubChangelogGenerator::Parser.user_project_from_option("blah", nil) }.to raise_error(SystemExit) }
+      it("should return nil") { expect(GitHubChangelogGenerator::Parser.user_project_from_option("blah", nil, nil)).to be_nil }
     end
 
     context "when option is valid" do
-      subject { GitHubChangelogGenerator::Parser.user_project_from_option("skywinder/ActionSheetPicker-3.0", nil) }
+      subject { GitHubChangelogGenerator::Parser.user_project_from_option("skywinder/ActionSheetPicker-3.0", nil, nil) }
       it { is_expected.to be_a(Array) }
       it { is_expected.to match_array(["skywinder", "ActionSheetPicker-3.0"]) }
     end
     context "when option nil" do
-      subject { GitHubChangelogGenerator::Parser.user_project_from_option(nil, nil) }
+      subject { GitHubChangelogGenerator::Parser.user_project_from_option(nil, nil, nil) }
       it { is_expected.to be_a(Array) }
       it { is_expected.to match_array([nil, nil]) }
     end


### PR DESCRIPTION
- Change: made the `Parser.user_project_from_option`  method require three arguments

This made my Rake task, configured like this, work; 1.10.0 hit an `exit` with a confusing error message:

```ruby
  GitHubChangelogGenerator::RakeTask.new(:changelog) do |config|
    config.author = false
    config.exclude_tags = /201[^4]|a.exe/
    config.release_branch = '2014.1'
  end
```

The confusing error message was:

```
> $ bundle exec rake releases:rebuild_changelog
releases:rebuild_changelog
Can't detect user and name from first parameter: 'releases:rebuild_changelog' -> exit'
```

(What happens in ARGV in my Rake task is not the concern of this class. We should work our way away from that bit. See line 198 in parser.rb.)

PS: The linting of the gemspec made Travis happier.