### PR TITLE
Added tag exclusion with a filter (string or regex)

### DIFF
--- a/lib/github_changelog_generator/fetcher.rb
+++ b/lib/github_changelog_generator/fetcher.rb
@@ -74,7 +74,7 @@ module GitHubChangelogGenerator
         if @options[:filter_tags]
           body_new = []
           reg = Regexp.new @options[:filter_tags]
-          page.body.each_with_index do |tag,index|
+          page.body.each do |tag|
             if !(tag.name =~ reg)
               body_new << tag
             end

--- a/lib/github_changelog_generator/fetcher.rb
+++ b/lib/github_changelog_generator/fetcher.rb
@@ -68,11 +68,25 @@ module GitHubChangelogGenerator
       response = @github.repos.tags @options[:user], @options[:project]
       page_i = 0
       count_pages = response.count_pages
+
       response.each_page do |page|
+
+        if @options[:filter_tags]
+          body_new = []
+          reg = Regexp.new @options[:filter_tags]
+          page.body.each_with_index do |tag,index|
+            if !(tag.name =~ reg)
+              body_new << tag
+            end
+          end
+          page.body = body_new
+        end
+
         page_i += PER_PAGE_NUMBER
         print_in_same_line("Fetching tags... #{page_i}/#{count_pages * PER_PAGE_NUMBER}")
         tags.concat(page)
       end
+
       print_empty_line
 
       if tags.count == 0

--- a/lib/github_changelog_generator/fetcher.rb
+++ b/lib/github_changelog_generator/fetcher.rb
@@ -71,9 +71,9 @@ module GitHubChangelogGenerator
 
       response.each_page do |page|
 
-        if @options[:filter_tags]
+        if @options[:exclude_tags_filter]
           body_new = []
-          reg = Regexp.new @options[:filter_tags]
+          reg = Regexp.new @options[:exclude_tags_filter]
           page.body.each do |tag|
             if !(tag.name =~ reg)
               body_new << tag

--- a/lib/github_changelog_generator/fetcher.rb
+++ b/lib/github_changelog_generator/fetcher.rb
@@ -68,25 +68,11 @@ module GitHubChangelogGenerator
       response = @github.repos.tags @options[:user], @options[:project]
       page_i = 0
       count_pages = response.count_pages
-
       response.each_page do |page|
-
-        if @options[:exclude_tags_filter]
-          body_new = []
-          reg = Regexp.new @options[:exclude_tags_filter]
-          page.body.each do |tag|
-            if !(tag.name =~ reg)
-              body_new << tag
-            end
-          end
-          page.body = body_new
-        end
-
         page_i += PER_PAGE_NUMBER
         print_in_same_line("Fetching tags... #{page_i}/#{count_pages * PER_PAGE_NUMBER}")
         tags.concat(page)
       end
-
       print_empty_line
 
       if tags.count == 0

--- a/lib/github_changelog_generator/generator/generator_tags.rb
+++ b/lib/github_changelog_generator/generator/generator_tags.rb
@@ -131,10 +131,10 @@ module GitHubChangelogGenerator
     # @param [Array] all_tags all tags
     # @return [Array] filtered tags according :exclude_tags or :exclude_tags_regex option
     def filter_excluded_tags(all_tags)
-      if (@options[:exclude_tags].is_a?(Regexp) || @options[:exclude_tags_regex])
-        filter_tags_with_regex(all_tags)
-      elsif @options[:exclude_tags]
-        filter_exact_tags(all_tags)
+      if @options[:exclude_tags]
+        apply_exclude_tags(all_tags)
+      elsif @options[:exclude_tags_regex]
+        apply_exclude_tags_regex(all_tags)
       else
         all_tags
       end
@@ -142,16 +142,21 @@ module GitHubChangelogGenerator
 
     private
 
-    def filter_tags_with_regex(all_tags)
-      warn_if_nonmatching_regex(all_tags)
-
-      if @options[:exclude_tags]
-        all_tags.reject { |tag| @options[:exclude_tags] =~ tag.name }
-      elsif @options[:exclude_tags_regex]
-        regex = Regexp.new(@options[:exclude_tags_regex])
-        all_tags.reject { |tag| regex =~ tag.name }
+    def apply_exclude_tags(all_tags)
+      if @options[:exclude_tags].is_a?(Regexp)
+        filter_tags_with_regex(all_tags, @options[:exclude_tags])
+      else
+        filter_exact_tags(all_tags)
       end
+    end
 
+    def apply_exclude_tags_regex(all_tags)
+      filter_tags_with_regex(all_tags, Regexp.new(@options[:exclude_tags_regex]))
+    end
+
+    def filter_tags_with_regex(all_tags, regex)
+      warn_if_nonmatching_regex(all_tags)
+      all_tags.reject { |tag| regex =~ tag.name }
     end
 
     def filter_exact_tags(all_tags)

--- a/lib/github_changelog_generator/generator/generator_tags.rb
+++ b/lib/github_changelog_generator/generator/generator_tags.rb
@@ -131,9 +131,13 @@ module GitHubChangelogGenerator
     # @param [Array] all_tags all tags
     # @return [Array] filtered tags according :exclude_tags option
     def filter_excluded_tags(all_tags)
-      return all_tags unless @options[:exclude_tags]
-
-      apply_exclude_tags(all_tags)
+      if @options[:exclude_tags]
+        apply_exclude_tags(all_tags)
+      elsif @options[:exclude_tags_regex]
+        apply_exclude_tags_regex(all_tags)
+      else
+        all_tags
+      end
     end
 
     private
@@ -146,9 +150,20 @@ module GitHubChangelogGenerator
       end
     end
 
+    def apply_exclude_tags_regex(all_tags)
+      filter_tags_with_regex(all_tags)
+    end
+
     def filter_tags_with_regex(all_tags)
       warn_if_nonmatching_regex(all_tags)
-      all_tags.reject { |tag| @options[:exclude_tags] =~ tag.name }
+
+      if @options[:exclude_tags]
+        all_tags.reject { |tag| @options[:exclude_tags] =~ tag.name }
+      elsif @options[:exclude_tags_regex]
+        regex = Regexp.new(@options[:exclude_tags_regex])
+        all_tags.reject { |tag| regex =~ tag.name }
+      end
+
     end
 
     def filter_exact_tags(all_tags)

--- a/lib/github_changelog_generator/generator/generator_tags.rb
+++ b/lib/github_changelog_generator/generator/generator_tags.rb
@@ -129,30 +129,18 @@ module GitHubChangelogGenerator
     end
 
     # @param [Array] all_tags all tags
-    # @return [Array] filtered tags according :exclude_tags option
+    # @return [Array] filtered tags according :exclude_tags or :exclude_tags_regex option
     def filter_excluded_tags(all_tags)
-      if @options[:exclude_tags]
-        apply_exclude_tags(all_tags)
-      elsif @options[:exclude_tags_regex]
-        apply_exclude_tags_regex(all_tags)
+      if (@options[:exclude_tags].is_a?(Regexp) || @options[:exclude_tags_regex])
+        filter_tags_with_regex(all_tags)
+      elsif @options[:exclude_tags]
+        filter_exact_tags(all_tags)
       else
         all_tags
       end
     end
 
     private
-
-    def apply_exclude_tags(all_tags)
-      if @options[:exclude_tags].is_a?(Regexp)
-        filter_tags_with_regex(all_tags)
-      else
-        filter_exact_tags(all_tags)
-      end
-    end
-
-    def apply_exclude_tags_regex(all_tags)
-      filter_tags_with_regex(all_tags)
-    end
 
     def filter_tags_with_regex(all_tags)
       warn_if_nonmatching_regex(all_tags)

--- a/lib/github_changelog_generator/parser.rb
+++ b/lib/github_changelog_generator/parser.rb
@@ -116,6 +116,9 @@ module GitHubChangelogGenerator
         opts.on("--between-tags  x,y,z", Array, "Change log will be filled only between specified tags") do |list|
           options[:between_tags] = list
         end
+        opts.on("--filter-tags [REGEX]", "Apply a regular expression on tag names so that they can be excluded, for example: --filter-tags \".*\+\d{1,}\" ") do |last|
+          options[:filter_tags] = last
+        end
         opts.on("--exclude-tags  x,y,z", Array, "Change log will exclude specified tags") do |list|
           options[:exclude_tags] = list
         end

--- a/lib/github_changelog_generator/parser.rb
+++ b/lib/github_changelog_generator/parser.rb
@@ -116,8 +116,8 @@ module GitHubChangelogGenerator
         opts.on("--between-tags  x,y,z", Array, "Change log will be filled only between specified tags") do |list|
           options[:between_tags] = list
         end
-        opts.on("--filter-tags [REGEX]", "Apply a regular expression on tag names so that they can be excluded, for example: --filter-tags \".*\+\d{1,}\" ") do |last|
-          options[:filter_tags] = last
+        opts.on("--exclude-tags-filter [REGEX]", "Apply a regular expression on tag names so that they can be excluded, for example: --exclude-tags-filter \".*\+\d{1,}\" ") do |last|
+          options[:exclude_tags_filter] = last
         end
         opts.on("--exclude-tags  x,y,z", Array, "Change log will exclude specified tags") do |list|
           options[:exclude_tags] = list

--- a/lib/github_changelog_generator/parser.rb
+++ b/lib/github_changelog_generator/parser.rb
@@ -116,11 +116,11 @@ module GitHubChangelogGenerator
         opts.on("--between-tags  x,y,z", Array, "Change log will be filled only between specified tags") do |list|
           options[:between_tags] = list
         end
-        opts.on("--exclude-tags-filter [REGEX]", "Apply a regular expression on tag names so that they can be excluded, for example: --exclude-tags-filter \".*\+\d{1,}\" ") do |last|
-          options[:exclude_tags_filter] = last
-        end
         opts.on("--exclude-tags  x,y,z", Array, "Change log will exclude specified tags") do |list|
           options[:exclude_tags] = list
+        end
+        opts.on("--exclude-tags-regex [REGEX]", "Apply a regular expression on tag names so that they can be excluded, for example: --exclude-tags-regex \".*\+\d{1,}\" ") do |last|
+          options[:exclude_tags_regex] = last
         end
         opts.on("--since-tag  x", "Change log will start after specified tag") do |v|
           options[:since_tag] = v

--- a/spec/unit/generator/generator_tags_spec.rb
+++ b/spec/unit/generator/generator_tags_spec.rb
@@ -74,12 +74,18 @@ describe GitHubChangelogGenerator::Generator do
   end
 
   describe "#filter_excluded_tags_regex" do
-    subject { generator.filter_excluded_tags(tags_mash_from_strings(%w(v1.2.3+12 v1.2.3))) }
+    subject { generator.filter_excluded_tags(tags_mash_from_strings(%w(1 2 3))) }
 
     context "with regex exclude_tags" do
-      let(:generator) { GitHubChangelogGenerator::Generator.new(exclude_tags_regex: '.*\+\d{1,}') }
+      let(:generator) { GitHubChangelogGenerator::Generator.new(exclude_tags_regex: '2') }
       it { is_expected.to be_a Array }
-      it { is_expected.to match_array(tags_mash_from_strings(%w(v1.2.3))) }
+      it { is_expected.to match_array(tags_mash_from_strings(%w(1 3))) }
+    end
+
+    context "with non-matching regex in exclude_tags" do
+      let(:generator) { GitHubChangelogGenerator::Generator.new(exclude_tags_regex: 'invalid tags') }
+      it { is_expected.to be_a Array }
+      it { is_expected.to match_array(tags_mash_from_strings(%w(1 2 3))) }
     end
   end
 

--- a/spec/unit/generator/generator_tags_spec.rb
+++ b/spec/unit/generator/generator_tags_spec.rb
@@ -76,13 +76,13 @@ describe GitHubChangelogGenerator::Generator do
   describe "#filter_excluded_tags_regex" do
     subject { generator.filter_excluded_tags(tags_mash_from_strings(%w(1 2 3))) }
 
-    context "with regex exclude_tags" do
+    context "with matching regex" do
       let(:generator) { GitHubChangelogGenerator::Generator.new(exclude_tags_regex: '2') }
       it { is_expected.to be_a Array }
       it { is_expected.to match_array(tags_mash_from_strings(%w(1 3))) }
     end
 
-    context "with non-matching regex in exclude_tags" do
+    context "with non-matching regex" do
       let(:generator) { GitHubChangelogGenerator::Generator.new(exclude_tags_regex: 'invalid tags') }
       it { is_expected.to be_a Array }
       it { is_expected.to match_array(tags_mash_from_strings(%w(1 2 3))) }
@@ -92,25 +92,25 @@ describe GitHubChangelogGenerator::Generator do
   describe "#filter_excluded_tags" do
     subject { generator.filter_excluded_tags(tags_mash_from_strings(%w(1 2 3))) }
 
-    context "with valid excluded tags" do
+    context "with matching string" do
       let(:generator) { GitHubChangelogGenerator::Generator.new(exclude_tags: %w(3)) }
       it { is_expected.to be_a Array }
       it { is_expected.to match_array(tags_mash_from_strings(%w(1 2))) }
     end
 
-    context "with invalid excluded tags" do
+    context "with non-matching string" do
       let(:generator) { GitHubChangelogGenerator::Generator.new(exclude_tags: %w(invalid tags)) }
       it { is_expected.to be_a Array }
       it { is_expected.to match_array(tags_mash_from_strings(%w(1 2 3))) }
     end
 
-    context "with regex exclude_tags" do
+    context "with matching regex" do
       let(:generator) { GitHubChangelogGenerator::Generator.new(exclude_tags: /[23]/) }
       it { is_expected.to be_a Array }
       it { is_expected.to match_array(tags_mash_from_strings(%w(1))) }
     end
 
-    context "with non-matching regex in exclude_tags" do
+    context "with non-matching regex" do
       let(:generator) { GitHubChangelogGenerator::Generator.new(exclude_tags: /[abc]/) }
       it { is_expected.to be_a Array }
       it { is_expected.to match_array(tags_mash_from_strings(%w(1 2 3))) }

--- a/spec/unit/generator/generator_tags_spec.rb
+++ b/spec/unit/generator/generator_tags_spec.rb
@@ -77,13 +77,13 @@ describe GitHubChangelogGenerator::Generator do
     subject { generator.filter_excluded_tags(tags_mash_from_strings(%w(1 2 3))) }
 
     context "with matching regex" do
-      let(:generator) { GitHubChangelogGenerator::Generator.new(exclude_tags_regex: '2') }
+      let(:generator) { GitHubChangelogGenerator::Generator.new(exclude_tags_regex: '[23]') }
       it { is_expected.to be_a Array }
-      it { is_expected.to match_array(tags_mash_from_strings(%w(1 3))) }
+      it { is_expected.to match_array(tags_mash_from_strings(%w(1))) }
     end
 
     context "with non-matching regex" do
-      let(:generator) { GitHubChangelogGenerator::Generator.new(exclude_tags_regex: 'invalid tags') }
+      let(:generator) { GitHubChangelogGenerator::Generator.new(exclude_tags_regex: '[45]') }
       it { is_expected.to be_a Array }
       it { is_expected.to match_array(tags_mash_from_strings(%w(1 2 3))) }
     end

--- a/spec/unit/generator/generator_tags_spec.rb
+++ b/spec/unit/generator/generator_tags_spec.rb
@@ -73,6 +73,16 @@ describe GitHubChangelogGenerator::Generator do
     end
   end
 
+  describe "#filter_excluded_tags_regex" do
+    subject { generator.filter_excluded_tags(tags_mash_from_strings(%w(v1.2.3+12 v1.2.3))) }
+
+    context "with regex exclude_tags" do
+      let(:generator) { GitHubChangelogGenerator::Generator.new(exclude_tags_regex: '.*\+\d{1,}') }
+      it { is_expected.to be_a Array }
+      it { is_expected.to match_array(tags_mash_from_strings(%w(v1.2.3))) }
+    end
+  end
+
   describe "#filter_excluded_tags" do
     subject { generator.filter_excluded_tags(tags_mash_from_strings(%w(1 2 3))) }
 

--- a/spec/unit/generator/generator_tags_spec.rb
+++ b/spec/unit/generator/generator_tags_spec.rb
@@ -73,22 +73,6 @@ describe GitHubChangelogGenerator::Generator do
     end
   end
 
-  describe "#filter_excluded_tags_regex" do
-    subject { generator.filter_excluded_tags(tags_mash_from_strings(%w(1 2 3))) }
-
-    context "with matching regex" do
-      let(:generator) { GitHubChangelogGenerator::Generator.new(exclude_tags_regex: '[23]') }
-      it { is_expected.to be_a Array }
-      it { is_expected.to match_array(tags_mash_from_strings(%w(1))) }
-    end
-
-    context "with non-matching regex" do
-      let(:generator) { GitHubChangelogGenerator::Generator.new(exclude_tags_regex: '[45]') }
-      it { is_expected.to be_a Array }
-      it { is_expected.to match_array(tags_mash_from_strings(%w(1 2 3))) }
-    end
-  end
-
   describe "#filter_excluded_tags" do
     subject { generator.filter_excluded_tags(tags_mash_from_strings(%w(1 2 3))) }
 
@@ -112,6 +96,22 @@ describe GitHubChangelogGenerator::Generator do
 
     context "with non-matching regex" do
       let(:generator) { GitHubChangelogGenerator::Generator.new(exclude_tags: /[abc]/) }
+      it { is_expected.to be_a Array }
+      it { is_expected.to match_array(tags_mash_from_strings(%w(1 2 3))) }
+    end
+  end
+
+  describe "#filter_excluded_tags_regex" do
+    subject { generator.filter_excluded_tags(tags_mash_from_strings(%w(1 2 3))) }
+
+    context "with matching regex" do
+      let(:generator) { GitHubChangelogGenerator::Generator.new(exclude_tags_regex: '[23]') }
+      it { is_expected.to be_a Array }
+      it { is_expected.to match_array(tags_mash_from_strings(%w(1))) }
+    end
+
+    context "with non-matching regex" do
+      let(:generator) { GitHubChangelogGenerator::Generator.new(exclude_tags_regex: '[45]') }
       it { is_expected.to be_a Array }
       it { is_expected.to match_array(tags_mash_from_strings(%w(1 2 3))) }
     end


### PR DESCRIPTION
Hi,

Here is a pull request to be able to exclude tag name with a regular expression.
I give you our use case, we have tags created by Jenkins including a build number, it looks like this:

```
v1.0.0+1234
```

We wanted to generated a changelog for all tags expect the one with a build number (+1234).

The command would look like this:

```
github_changelog_generator --exclude-tags-regex ".*\+\d{1,}"
```

Quick note: this is the first time I write ruby, so I did what I could. I wanted to add a rspec test for it, but it is a bit beyond me, If anyone wants to help, feel free!

We can use the forked version in our pipeline, but if that PR makes sense to you, here you go!

Cheers.


