### PR TITLE
Fix crash installing on systems without overcommit

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,5 +8,4 @@ group :test do
   gem "coveralls", "~>0.8", require: false
   gem "simplecov", "~>0.10", require: false
   gem "codeclimate-test-reporter", "~>0.4"
-  gem "overcommit", "~>0.31"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ PATH
     github_changelog_generator (1.10.3)
       colorize (~> 0.7)
       github_api (~> 0.12)
+      overcommit (~> 0.31)
 
 GEM
   remote: https://rubygems.org/
@@ -97,7 +98,6 @@ DEPENDENCIES
   codeclimate-test-reporter (~> 0.4)
   coveralls (~> 0.8)
   github_changelog_generator!
-  overcommit (~> 0.31)
   rake (~> 10.0)
   rspec (~> 3.2)
   rubocop (~> 0.31)

--- a/github_changelog_generator.gemspec
+++ b/github_changelog_generator.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency("github_api", ["~> 0.12"])
   spec.add_runtime_dependency("colorize", ["~> 0.7"])
+  spec.add_runtime_dependency("overcommit", "~>0.31")
 
   # Development only
   spec.add_development_dependency "bundler", "~> 1.7"


### PR DESCRIPTION
If Rakefile is an extension, any requires in `Rakefile` are runtime deps, sadly :/ This is affecting all of Chef's travis runs right now.

Repro:

```bash
gem uninstall overcommit
gem install github_changelog_generator
```

Expected Results: success
Actual Results:
```
Building native extensions.  This could take a while...
ERROR:  Error installing pkg/github_changelog_generator-1.10.3.gem:
	ERROR: Failed to build gem native extension.

    /usr/local/var/rbenv/versions/2.2.3/bin/ruby -rubygems /usr/local/var/rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/rake-10.5.0/bin/rake RUBYARCHDIR=/usr/local/var/rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/extensions/x86_64-darwin-15/2.2.0-static/github_changelog_generator-1.10.3 RUBYLIBDIR=/usr/local/var/rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/extensions/x86_64-darwin-15/2.2.0-static/github_changelog_generator-1.10.3
rake aborted!
LoadError: cannot load such file -- overcommit
```