### PR TITLE
Test case for #327

### DIFF
--- a/spec/files/github_changelog_params_327
+++ b/spec/files/github_changelog_params_327
@@ -1,0 +1,1 @@
+exclude-labels=73a91042-da6f-11e5-9335-1040f38d7f90,7adf83b4-da6f-11e5-ae18-1040f38d7f90

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,11 +23,11 @@ require "coveralls"
 module SpecHelper
 end
 
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
   Coveralls::SimpleCov::Formatter,
   SimpleCov::Formatter::HTMLFormatter,
   CodeClimate::TestReporter::Formatter
-]
+])
 SimpleCov.start
 
 require "github_changelog_generator"

--- a/spec/unit/parse_file_spec.rb
+++ b/spec/unit/parse_file_spec.rb
@@ -36,6 +36,20 @@ describe GitHubChangelogGenerator::ParserFile do
                                           unreleased: false,
                                           header: "=== Changelog ==="))
       end
+
+      context "turns exclude-label into an Array", bug: '#327' do
+        let(:options) {
+          {
+            params_file: 'spec/files/github_changelog_params_327'
+          }
+        }
+        it "reads exclude_labels into an Array" do
+          expect { parse.parse! }.to change { options[:exclude_labels] }
+                                       .from(nil)
+                                       .to(["73a91042-da6f-11e5-9335-1040f38d7f90", "7adf83b4-da6f-11e5-ae18-1040f38d7f90"])
+
+        end
+      end
     end
   end
 end

--- a/spec/unit/parse_file_spec.rb
+++ b/spec/unit/parse_file_spec.rb
@@ -37,7 +37,7 @@ describe GitHubChangelogGenerator::ParserFile do
                                           header: "=== Changelog ==="))
       end
 
-      context "turns exclude-label into an Array", bug: '#327' do
+      context "turns exclude-labels into an Array", bug: '#327' do
         let(:options) {
           {
             params_file: 'spec/files/github_changelog_params_327'


### PR DESCRIPTION
Here is a failing test-case for part of #327 - the "read options from a file" code does not apply the OptionParser type conversions.