### PR TITLE
Add rubocop and rspec as runtime dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,6 @@ source "https://rubygems.org"
 gemspec
 
 group :test do
-  gem "rspec", "~>3.2"
-  gem "rubocop", "~>0.31"
   gem "coveralls", "~>0.8", require: false
   gem "simplecov", "~>0.10", require: false
   gem "codeclimate-test-reporter", "~>0.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,11 +2,13 @@ PATH
   remote: .
   specs:
     github_changelog_generator (1.10.4)
-      bundler (~> 1.7)
+      bundler (>= 1.7)
       colorize (~> 0.7)
       github_api (~> 0.12)
-      overcommit (~> 0.31)
-      rake (~> 10.0)
+      overcommit (>= 0.31)
+      rake (>= 10.0)
+      rspec (>= 3.2)
+      rubocop (>= 0.31)
 
 GEM
   remote: https://rubygems.org/
@@ -99,8 +101,6 @@ DEPENDENCIES
   codeclimate-test-reporter (~> 0.4)
   coveralls (~> 0.8)
   github_changelog_generator!
-  rspec (~> 3.2)
-  rubocop (~> 0.31)
   simplecov (~> 0.10)
 
 BUNDLED WITH

--- a/github_changelog_generator.gemspec
+++ b/github_changelog_generator.gemspec
@@ -24,11 +24,11 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "rake", "~> 10.0"
-  spec.add_runtime_dependency "bundler", "~> 1.7"
+  spec.add_runtime_dependency "rake", ">= 10.0"
+  spec.add_runtime_dependency "bundler", ">= 1.7"
   spec.add_runtime_dependency("github_api", ["~> 0.12"])
   spec.add_runtime_dependency("colorize", ["~> 0.7"])
-  spec.add_runtime_dependency("overcommit", "~>0.31")
-  spec.add_runtime_dependency("rubocop", "~>0.31")
-  spec.add_runtime_dependency("rspec", "~>3.2")
+  spec.add_runtime_dependency("overcommit", ">= 0.31")
+  spec.add_runtime_dependency("rubocop", ">= 0.31")
+  spec.add_runtime_dependency("rspec", ">= 3.2")
 end

--- a/github_changelog_generator.gemspec
+++ b/github_changelog_generator.gemspec
@@ -29,4 +29,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency("github_api", ["~> 0.12"])
   spec.add_runtime_dependency("colorize", ["~> 0.7"])
   spec.add_runtime_dependency("overcommit", "~>0.31")
+  spec.add_runtime_dependency("rubocop", "~>0.31")
+  spec.add_runtime_dependency("rspec", "~>3.2")
 end


### PR DESCRIPTION
Repro:
1. `gem uninstall rubocop rspec`
2. `gem install github_changelog_generator`

```
Building native extensions.  This could take a while...
ERROR:  Error installing github_changelog_generator:
	ERROR: Failed to build gem native extension.

    current directory: /usr/local/var/rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/github_changelog_generator-1.11.0
/usr/local/var/rbenv/versions/2.2.3/bin/ruby -rubygems /usr/local/var/rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/rake-10.5.0/bin/rake RUBYARCHDIR=/usr/local/var/rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/extensions/x86_64-darwin-15/2.2.0-static/github_changelog_generator-1.11.0 RUBYLIBDIR=/usr/local/var/rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/extensions/x86_64-darwin-15/2.2.0-static/github_changelog_generator-1.11.0
rake aborted!
LoadError: cannot load such file -- rubocop/rake_task
```