### PR TITLE
Man page copying: only copy .1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,10 @@ source "https://rubygems.org"
 gemspec
 
 group :test do
+  gem "rake"
+  gem "bundler"
+  gem "rubocop"
+  gem "overcommit"
   gem "coveralls", "~>0.8", require: false
   gem "simplecov", "~>0.10", require: false
   gem "codeclimate-test-reporter", "~>0.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    github_changelog_generator (1.11.2)
+    github_changelog_generator (1.11.3)
       bundler (>= 1.7)
       colorize (~> 0.7)
       github_api (~> 0.12)
@@ -98,9 +98,13 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  bundler
   codeclimate-test-reporter (~> 0.4)
   coveralls (~> 0.8)
   github_changelog_generator!
+  overcommit
+  rake
+  rubocop
   simplecov (~> 0.10)
 
 BUNDLED WITH

--- a/Rakefile
+++ b/Rakefile
@@ -15,7 +15,7 @@ task :create_man do |_t|
   man_pages = "man/git-*.1"
 
   Pathname.glob(man_pages) do |path|
-    if path.exist? && man_prefix.exist?
+    if path.exist? && man_prefix.exist? && man_prefix.writable?
       FileUtils.cp(path, man_prefix + path.basename)
     end
   end

--- a/Rakefile
+++ b/Rakefile
@@ -10,8 +10,14 @@ RuboCop::RakeTask.new
 RSpec::Core::RakeTask.new(:rspec)
 
 task :create_man do |_t|
-  os_prefix = "/usr/local"
-  man_prefix = Pathname("#{os_prefix}/share/man/man1")
+  writable_man_path = Pathname('/etc/manpaths').each_line.find do |line|
+    path = Pathname(line.chomp)
+    path.directory? && path.writable?
+  end rescue nil
+
+  return unless writable_man_path
+
+  man_prefix = Pathname("#{writable_man_path.chomp}/man1")
   man_pages = "man/git-*.1"
 
   Pathname.glob(man_pages) do |path|

--- a/Rakefile
+++ b/Rakefile
@@ -9,11 +9,19 @@ require "overcommit"
 RuboCop::RakeTask.new
 RSpec::Core::RakeTask.new(:rspec)
 
-task :create_man do |_t|
-  writable_man_path = Pathname('/etc/manpaths').each_line.find do |line|
+task :copy_man_page_to_manpath do |_t|
+  known_manpath_paths = %w(/etc/manpath.config /etc/manpaths)
+  manpath = known_manpath_paths.find do |f|
+    path = Pathname(f)
+    path.file? && path.readable?
+  end
+
+  return unless manpath
+
+  writable_man_path = Pathname(manpath).each_line.find do |line|
     path = Pathname(line.chomp)
     path.directory? && path.writable?
-  end rescue nil
+  end
 
   return unless writable_man_path
 
@@ -28,4 +36,4 @@ task :create_man do |_t|
 end
 
 task checks: [:rubocop, :rspec]
-task default: [:create_man]
+task default: [:copy_man_page_to_manpath]

--- a/Rakefile
+++ b/Rakefile
@@ -12,10 +12,12 @@ RSpec::Core::RakeTask.new(:rspec)
 task :create_man do |_t|
   os_prefix = "/usr/local"
   man_prefix = Pathname("#{os_prefix}/share/man/man1")
-  man_pages = "man/git-*"
+  man_pages = "man/git-*.1"
 
   Pathname.glob(man_pages) do |path|
-    FileUtils.cp(path, man_prefix + path.basename)
+    if path.exist? && man_prefix.exist?
+      FileUtils.cp(path, man_prefix + path.basename)
+    end
   end
 end
 

--- a/github_changelog_generator.gemspec
+++ b/github_changelog_generator.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.description = "Changelog generation has never been so easy. Fully automate changelog generation - this gem generate change log file based on tags, issues and merged pull requests from Github issue tracker."
   spec.homepage = "https://github.com/skywinder/Github-Changelog-Generator"
   spec.license = "MIT"
-  #spec.extensions = ["Rakefile"]
+  spec.extensions = ["Rakefile"]
 
   spec.files = `git ls-files -z`.split("\x0")
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }


### PR DESCRIPTION
Check if possible first, then copy the `github-changelog-generator.1` file to `/usr/local/share/man/man1/`.

(This reinstates gems in gemfile needed to run tests on Travis.)

- On OS X, look for manpaths in the `/etc/manpaths`
- On Ubuntu, look for manpaths  in the `/etc/manpath.config`

---

What other file locations on a system can credibly be used? 