### PR TITLE
README: Document GitHub token URI scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Therefore, it's recommended to run this script with authentication by using a **
 
 Here's how:
 
-- [Generate a token here](https://github.com/settings/tokens/new?description=GitHub%20Changelog%20Generator%20token)
+- [Generate a token here](https://github.com/settings/tokens/new?description=GitHub%20Changelog%20Generator%20token) - you only need "repo" scope for private repositories
 - Either:
     - Run the script with `--token <your-40-digit-token>`; **OR**
     - Set the `CHANGELOG_GITHUB_TOKEN` environment variable to your 40 digit token


### PR DESCRIPTION
Docs note.

[You can read more about the scopes here](https://developer.github.com/v3/oauth/#scopes), and the interface says so.  Perhaps the text should be: "To use a private repo, use `&scopes=repo`" (as a link)?