### PR TITLE
Parse options file options into arrays, integers, flags, and other

### DIFF
--- a/lib/github_changelog_generator/parser_file.rb
+++ b/lib/github_changelog_generator/parser_file.rb
@@ -23,7 +23,7 @@ module GitHubChangelogGenerator
 
     def parse_line!(line)
       key_sym, value = extract_pair(line)
-      @options[key_sym] = convert_value(value, key_sym)
+      @options[translate_option_name(key_sym)] = convert_value(value, key_sym)
     rescue
       raise ParserError, "Config file #{file} is incorrect in line \"#{line.gsub(/[\n\r]+/, '')}\""
     end
@@ -53,6 +53,22 @@ module GitHubChangelogGenerator
       else
         value
       end
+    end
+
+    def translate_option_name(key_sym)
+      {
+        bugs_label: :bug_prefix,
+        enhancement_label: :enhancement_prefix,
+        issues_label: :issue_prefix,
+        header_label: :header,
+        front_matter: :frontmatter,
+        pr_label: :merge_prefix,
+        issues_wo_labels: :add_issues_wo_labels,
+        pr_wo_labels: :add_pr_wo_labels,
+        pull_requests: :pulls,
+        filter_by_milestone: :filter_issues_by_milestone,
+        github_api: :github_endpoint
+      }.fetch(key_sym) { key_sym }
     end
   end
 end

--- a/spec/files/github_changelog_params_327
+++ b/spec/files/github_changelog_params_327
@@ -1,1 +1,2 @@
 exclude-labels=73a91042-da6f-11e5-9335-1040f38d7f90,7adf83b4-da6f-11e5-ae18-1040f38d7f90
+header_label=# My changelog

--- a/spec/unit/parse_file_spec.rb
+++ b/spec/unit/parse_file_spec.rb
@@ -43,10 +43,17 @@ describe GitHubChangelogGenerator::ParserFile do
             params_file: "spec/files/github_changelog_params_327"
           }
         end
+
         it "reads exclude_labels into an Array" do
           expect { parse.parse! }.to change { options[:exclude_labels] }
             .from(nil)
             .to(["73a91042-da6f-11e5-9335-1040f38d7f90", "7adf83b4-da6f-11e5-ae18-1040f38d7f90"])
+        end
+
+        it "translates given header_label into the :header option" do
+          expect { parse.parse! }.to change { options[:header] }
+            .from(nil)
+            .to("# My changelog")
         end
       end
     end

--- a/spec/unit/parse_file_spec.rb
+++ b/spec/unit/parse_file_spec.rb
@@ -44,7 +44,6 @@ describe GitHubChangelogGenerator::ParserFile do
           }
         end
         it "reads exclude_labels into an Array" do
-          pending("Related with Bug #327.")
           expect { parse.parse! }.to change { options[:exclude_labels] }
             .from(nil)
             .to(["73a91042-da6f-11e5-9335-1040f38d7f90", "7adf83b4-da6f-11e5-ae18-1040f38d7f90"])


### PR DESCRIPTION
The file-based `.github_changelog_generator` options support has been less than perfect. This PR wants to do the same options translation that happens in the OptionParser in the `parser.rb` file, for the file-based settings.

- Respect each option's type (Array, Integer, flag, anything), according to #327 
- Rename each given setting to its option, according to #312.

- Q: Do we need better parsing of the array values than `#split(",")`? Answer: [no, this is what OptionParser's Array coercion does](http://ruby-doc.org/stdlib-2.3.0/libdoc/optparse/rdoc/OptionParser.html#class-OptionParser-label-Type+Coercion)

Fix #327 
