### PR TITLE
On gem install, do not try to copy manpage files in the "extensions" step

### DIFF
--- a/github_changelog_generator.gemspec
+++ b/github_changelog_generator.gemspec
@@ -16,7 +16,6 @@ Gem::Specification.new do |spec|
   spec.description = "Changelog generation has never been so easy. Fully automate changelog generation - this gem generate change log file based on tags, issues and merged pull requests from Github issue tracker."
   spec.homepage = "https://github.com/skywinder/Github-Changelog-Generator"
   spec.license = "MIT"
-  spec.extensions = ["Rakefile"]
 
   spec.files = `git ls-files -z`.split("\x0")
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }


### PR DESCRIPTION
To dodge all issues with "you need git, you need Bundler, you need ..." when performing the "extensions" step in the install process, this change wants to drop that step.

Problems to solve:
- see #349 

What we miss out on with this change: man pages will no longer be copied to a location guessed by the Rakefile. (These man pages are not automatically updated.)