### PR TITLE
ParserFile: fail parsing with config file line number; use a File instead of a filename

### DIFF
--- a/lib/github_changelog_generator/parser_file.rb
+++ b/lib/github_changelog_generator/parser_file.rb
@@ -16,14 +16,11 @@ module GitHubChangelogGenerator
     end
 
     def read_default_file
+      path = Pathname(File.expand_path(FILENAME))
       File.open(path) if path.exist?
     end
 
-    def path
-      @path ||= Pathname(File.expand_path(FILENAME))
-    end
-
-    # Destructively change @options using data in configured options file.
+    # Set @options using configuration file lines.
     def parse!
       return unless file
       file.each_line { |line| parse_line!(line) }

--- a/lib/github_changelog_generator/parser_file.rb
+++ b/lib/github_changelog_generator/parser_file.rb
@@ -44,7 +44,7 @@ module GitHubChangelogGenerator
       option_name, value = extract_pair(line)
       @options[option_key_for(option_name)] = convert_value(value, option_name)
     rescue
-      raise ParserError, "Config file parsing failed on line ##{line_number}: \"#{line.gsub(/[\n\r]+/, '')}\""
+      raise ParserError, "Failed on line ##{line_number}: \"#{line.gsub(/[\n\r]+/, '')}\""
     end
 
     # Returns a the option name as a symbol and its string value sans newlines.

--- a/lib/github_changelog_generator/parser_file.rb
+++ b/lib/github_changelog_generator/parser_file.rb
@@ -21,17 +21,17 @@ module GitHubChangelogGenerator
     # Set @options using configuration file lines.
     def parse!
       return unless @file
-      @file.each_line { |line| parse_line!(line) }
+      @file.each_with_index { |line, i| parse_line!(line, i + 1) }
       @file.close
     end
 
     private
 
-    def parse_line!(line)
+    def parse_line!(line, line_number)
       option_name, value = extract_pair(line)
       @options[option_key_for(option_name)] = convert_value(value, option_name)
     rescue
-      raise ParserError, "Config file problem on line \"#{line.gsub(/[\n\r]+/, '')}\""
+      raise ParserError, "Config file parsing failed on line ##{line_number}: \"#{line.gsub(/[\n\r]+/, '')}\""
     end
 
     # Returns a the option name as a symbol and its string value sans newlines.

--- a/lib/github_changelog_generator/parser_file.rb
+++ b/lib/github_changelog_generator/parser_file.rb
@@ -6,20 +6,31 @@ module GitHubChangelogGenerator
   class ParserFile
     FILENAME = ".github_changelog_generator"
 
-    def initialize(options)
+    attr_reader :file
+
+    # @param options [Hash]
+    # @param file [nil,IO]
+    def initialize(options, file = read_default_file)
       @options = options
+      @file = file
+    end
+
+    def read_default_file
+      File.open(path) if path.exist?
+    end
+
+    def path
+      @path ||= Pathname(File.expand_path(FILENAME))
     end
 
     # Destructively change @options using data in configured options file.
     def parse!
-      file.each_line { |line| parse_line!(line) } if file.exist?
+      return unless file
+      file.each_line { |line| parse_line!(line) }
+      file.close
     end
 
     private
-
-    def file
-      @file ||= Pathname(File.expand_path(@options[:params_file] || FILENAME))
-    end
 
     def parse_line!(line)
       option_name, value = extract_pair(line)

--- a/lib/github_changelog_generator/parser_file.rb
+++ b/lib/github_changelog_generator/parser_file.rb
@@ -3,22 +3,28 @@ require "pathname"
 module GitHubChangelogGenerator
   ParserError = Class.new(StandardError)
 
+  # ParserFile is a configuration file reader which sets options in the
+  # given Hash.
+  #
+  # In your project's root, you can put a file named
+  # <tt>.github_changelog_generator</tt> to override defaults:
+  #
+  # Example:
+  #   header_label=# My Super Changelog
+  #   future-release=5.0.0
+  #   since-tag=1.0.0
+  #
+  # The configuration format is <tt>some-key=value</tt> or <tt>some_key=value</tt>.
+  #
   class ParserFile
-    FILENAME = ".github_changelog_generator"
-
-    # @param options [Hash]
-    # @param file [nil,IO]
+    # @param options [Hash] options to be configured from file contents
+    # @param file [nil,IO] configuration file handle, defaults to opening `.github_changelog_generator`
     def initialize(options, file = read_default_file)
       @options = options
       @file = file
     end
 
-    def read_default_file
-      path = Pathname(File.expand_path(FILENAME))
-      File.open(path) if path.exist?
-    end
-
-    # Set @options using configuration file lines.
+    # Sets options using configuration file content
     def parse!
       return unless @file
       @file.each_with_index { |line, i| parse_line!(line, i + 1) }
@@ -26,6 +32,13 @@ module GitHubChangelogGenerator
     end
 
     private
+
+    FILENAME = ".github_changelog_generator"
+
+    def read_default_file
+      path = Pathname(File.expand_path(FILENAME))
+      File.open(path) if path.exist?
+    end
 
     def parse_line!(line, line_number)
       option_name, value = extract_pair(line)

--- a/lib/github_changelog_generator/parser_file.rb
+++ b/lib/github_changelog_generator/parser_file.rb
@@ -6,8 +6,6 @@ module GitHubChangelogGenerator
   class ParserFile
     FILENAME = ".github_changelog_generator"
 
-    attr_reader :file
-
     # @param options [Hash]
     # @param file [nil,IO]
     def initialize(options, file = read_default_file)
@@ -22,9 +20,9 @@ module GitHubChangelogGenerator
 
     # Set @options using configuration file lines.
     def parse!
-      return unless file
-      file.each_line { |line| parse_line!(line) }
-      file.close
+      return unless @file
+      @file.each_line { |line| parse_line!(line) }
+      @file.close
     end
 
     private
@@ -33,7 +31,7 @@ module GitHubChangelogGenerator
       option_name, value = extract_pair(line)
       @options[option_key_for(option_name)] = convert_value(value, option_name)
     rescue
-      raise ParserError, "Config file #{file} is incorrect in line \"#{line.gsub(/[\n\r]+/, '')}\""
+      raise ParserError, "Config file problem on line \"#{line.gsub(/[\n\r]+/, '')}\""
     end
 
     # Returns a the option name as a symbol and its string value sans newlines.

--- a/lib/github_changelog_generator/parser_file.rb
+++ b/lib/github_changelog_generator/parser_file.rb
@@ -19,7 +19,7 @@ module GitHubChangelogGenerator
   class ParserFile
     # @param options [Hash] options to be configured from file contents
     # @param file [nil,IO] configuration file handle, defaults to opening `.github_changelog_generator`
-    def initialize(options, file = read_default_file)
+    def initialize(options, file = open_settings_file)
       @options = options
       @file = file
     end
@@ -35,7 +35,7 @@ module GitHubChangelogGenerator
 
     FILENAME = ".github_changelog_generator"
 
-    def read_default_file
+    def open_settings_file
       path = Pathname(File.expand_path(FILENAME))
       File.open(path) if path.exist?
     end

--- a/spec/files/github_changelog_params_327
+++ b/spec/files/github_changelog_params_327
@@ -1,2 +1,0 @@
-exclude-labels=73a91042-da6f-11e5-9335-1040f38d7f90,7adf83b4-da6f-11e5-ae18-1040f38d7f90
-header_label=# My changelog

--- a/spec/files/github_changelog_params_incorrect
+++ b/spec/files/github_changelog_params_incorrect
@@ -1,2 +1,0 @@
-unreleased_label: staging
-unreleased: false

--- a/spec/files/github_changelog_params_override
+++ b/spec/files/github_changelog_params_override
@@ -1,3 +1,0 @@
-unreleased_label=staging
-unreleased=false
-header==== Changelog ===

--- a/spec/unit/parse_file_spec.rb
+++ b/spec/unit/parse_file_spec.rb
@@ -2,17 +2,17 @@ describe GitHubChangelogGenerator::ParserFile do
   describe ".github_changelog_generator" do
     context "when no has file" do
       let(:options) { {} }
-      let(:parse) { GitHubChangelogGenerator::ParserFile.new(options) }
-      subject { parse.parse! }
+      let(:parser) { GitHubChangelogGenerator::ParserFile.new(options) }
+      subject { parser.parse! }
       it { is_expected.to be_nil }
     end
 
     context "when file is empty" do
       let(:options) { {} }
-      let(:parse) { GitHubChangelogGenerator::ParserFile.new(options, StringIO.new("")) }
+      let(:parser) { GitHubChangelogGenerator::ParserFile.new(options, StringIO.new("")) }
 
       it "does not change the options" do
-        expect { parse.parse! }.to_not change { options }
+        expect { parser.parse! }.to_not change { options }
       end
     end
 
@@ -20,10 +20,10 @@ describe GitHubChangelogGenerator::ParserFile do
       let(:options) { {} }
       let(:options_before_change) { options.dup }
       let(:file) { StringIO.new("unreleased_label=staging\nunreleased: false") }
-      let(:parse) do
+      let(:parser) do
         GitHubChangelogGenerator::ParserFile.new(options, file)
       end
-      it { expect { parse.parse! }.to raise_error(/line #2/) }
+      it { expect { parser.parse! }.to raise_error(/line #2/) }
     end
 
     context "when override default values" do
@@ -31,10 +31,10 @@ describe GitHubChangelogGenerator::ParserFile do
       let(:options) { {}.merge(default_options) }
       let(:options_before_change) { options.dup }
       let(:file) { StringIO.new("unreleased_label=staging\nunreleased=false\nheader==== Changelog ===") }
-      let(:parse) { GitHubChangelogGenerator::ParserFile.new(options, file) }
+      let(:parser) { GitHubChangelogGenerator::ParserFile.new(options, file) }
 
       it "changes the options" do
-        expect { parse.parse! }.to change { options }
+        expect { parser.parse! }.to change { options }
           .from(options_before_change)
           .to(options_before_change.merge(unreleased_label: "staging",
                                           unreleased: false,
@@ -50,13 +50,13 @@ EOF
                       )
         end
         it "reads exclude_labels into an Array" do
-          expect { parse.parse! }.to change { options[:exclude_labels] }
+          expect { parser.parse! }.to change { options[:exclude_labels] }
             .from(default_options[:exclude_labels])
             .to(["73a91042-da6f-11e5-9335-1040f38d7f90", "7adf83b4-da6f-11e5-ae18-1040f38d7f90"])
         end
 
         it "translates given header_label into the :header option" do
-          expect { parse.parse! }.to change { options[:header] }
+          expect { parser.parse! }.to change { options[:header] }
             .from(default_options[:header])
             .to("# My changelog")
         end

--- a/spec/unit/parse_file_spec.rb
+++ b/spec/unit/parse_file_spec.rb
@@ -19,11 +19,11 @@ describe GitHubChangelogGenerator::ParserFile do
     context "when file is incorrect" do
       let(:options) { {} }
       let(:options_before_change) { options.dup }
-      let(:file) { StringIO.new("unreleased_label: staging\nunreleased: false") }
+      let(:file) { StringIO.new("unreleased_label=staging\nunreleased: false") }
       let(:parse) do
         GitHubChangelogGenerator::ParserFile.new(options, file)
       end
-      it { expect { parse.parse! }.to raise_error(GitHubChangelogGenerator::ParserError) }
+      it { expect { parse.parse! }.to raise_error(/line #2/) }
     end
 
     context "when override default values" do

--- a/spec/unit/parse_file_spec.rb
+++ b/spec/unit/parse_file_spec.rb
@@ -8,8 +8,8 @@ describe GitHubChangelogGenerator::ParserFile do
     end
 
     context "when file is empty" do
-      let(:options) { { params_file: "spec/files/github_changelog_params_empty" } }
-      let(:parse) { GitHubChangelogGenerator::ParserFile.new(options) }
+      let(:options) { {} }
+      let(:parse) { GitHubChangelogGenerator::ParserFile.new(options, StringIO.new("")) }
 
       it "does not change the options" do
         expect { parse.parse! }.to_not change { options }
@@ -17,17 +17,21 @@ describe GitHubChangelogGenerator::ParserFile do
     end
 
     context "when file is incorrect" do
-      let(:options) { { params_file: "spec/files/github_changelog_params_incorrect" } }
+      let(:options) { {} }
       let(:options_before_change) { options.dup }
-      let(:parse) { GitHubChangelogGenerator::ParserFile.new(options) }
+      let(:file) { StringIO.new("unreleased_label: staging\nunreleased: false") }
+      let(:parse) do
+        GitHubChangelogGenerator::ParserFile.new(options, file)
+      end
       it { expect { parse.parse! }.to raise_error(GitHubChangelogGenerator::ParserError) }
     end
 
     context "when override default values" do
       let(:default_options) { GitHubChangelogGenerator::Parser.default_options }
-      let(:options) { { params_file: "spec/files/github_changelog_params_override" }.merge(default_options) }
+      let(:options) { {}.merge(default_options) }
       let(:options_before_change) { options.dup }
-      let(:parse) { GitHubChangelogGenerator::ParserFile.new(options) }
+      let(:file) { StringIO.new("unreleased_label=staging\nunreleased=false\nheader==== Changelog ===") }
+      let(:parse) { GitHubChangelogGenerator::ParserFile.new(options, file) }
 
       it "changes the options" do
         expect { parse.parse! }.to change { options }
@@ -38,21 +42,22 @@ describe GitHubChangelogGenerator::ParserFile do
       end
 
       context "turns exclude-labels into an Array", bug: '#327' do
-        let(:options) do
-          {
-            params_file: "spec/files/github_changelog_params_327"
-          }
+        let(:file) do
+          StringIO.new(<<EOF
+exclude-labels=73a91042-da6f-11e5-9335-1040f38d7f90,7adf83b4-da6f-11e5-ae18-1040f38d7f90
+header_label=# My changelog
+EOF
+                      )
         end
-
         it "reads exclude_labels into an Array" do
           expect { parse.parse! }.to change { options[:exclude_labels] }
-            .from(nil)
+            .from(default_options[:exclude_labels])
             .to(["73a91042-da6f-11e5-9335-1040f38d7f90", "7adf83b4-da6f-11e5-ae18-1040f38d7f90"])
         end
 
         it "translates given header_label into the :header option" do
           expect { parse.parse! }.to change { options[:header] }
-            .from(nil)
+            .from(default_options[:header])
             .to("# My changelog")
         end
       end


### PR DESCRIPTION
This change allows tests to pass in a file-like object instead of having to manage real files. [I had fun reading this while making this happen](https://robots.thoughtbot.com/io-in-ruby).

- drops spec fixture files for `.github_changelog_generator`, using StringIO objects next to the tests instead
- report configuration file parse failure with the line number in the error message
- docs
- improved naming