### PR TITLE
ParserFile: Allow comments in settings file

### DIFF
--- a/lib/github_changelog_generator/parser_file.rb
+++ b/lib/github_changelog_generator/parser_file.rb
@@ -52,7 +52,7 @@ module GitHubChangelogGenerator
 
     # Returns true if the line starts with a pound sign or a semi-colon.
     def non_configuration_line?(line)
-      line =~ /^[\#;]/
+      line =~ /^[\#;]/ || line =~ /^[\s]+$/
     end
 
     # Returns a the option name as a symbol and its string value sans newlines.

--- a/lib/github_changelog_generator/parser_file.rb
+++ b/lib/github_changelog_generator/parser_file.rb
@@ -7,11 +7,13 @@ module GitHubChangelogGenerator
   # given Hash.
   #
   # In your project's root, you can put a file named
-  # <tt>.github_changelog_generator</tt> to override defaults:
+  # <tt>.github_changelog_generator</tt> to override defaults.
   #
   # Example:
   #   header_label=# My Super Changelog
+  #   ; Comments are allowed
   #   future-release=5.0.0
+  #   # Ruby-style comments, too
   #   since-tag=1.0.0
   #
   # The configuration format is <tt>some-key=value</tt> or <tt>some_key=value</tt>.
@@ -41,10 +43,16 @@ module GitHubChangelogGenerator
     end
 
     def parse_line!(line, line_number)
+      return if non_configuration_line?(line)
       option_name, value = extract_pair(line)
       @options[option_key_for(option_name)] = convert_value(value, option_name)
     rescue
       raise ParserError, "Failed on line ##{line_number}: \"#{line.gsub(/[\n\r]+/, '')}\""
+    end
+
+    # Returns true if the line starts with a pound sign or a semi-colon.
+    def non_configuration_line?(line)
+      line =~ /^[\#;]/
     end
 
     # Returns a the option name as a symbol and its string value sans newlines.

--- a/spec/unit/parse_file_spec.rb
+++ b/spec/unit/parse_file_spec.rb
@@ -25,8 +25,8 @@ describe GitHubChangelogGenerator::ParserFile do
       it { expect { parser.parse! }.to raise_error(/line #2/) }
     end
 
-    context "allows comments with semi-colon or pound sign" do
-      let(:file) { StringIO.new("# Comment on first line\nunreleased_label=staging\n; Comment on third line\nunreleased=false") }
+    context "allows empty lines and comments with semi-colon or pound sign" do
+      let(:file) { StringIO.new("\n   \n# Comment on first line\nunreleased_label=staging\n; Comment on third line\nunreleased=false") }
       let(:parser) do
         GitHubChangelogGenerator::ParserFile.new(options, file)
       end

--- a/spec/unit/parse_file_spec.rb
+++ b/spec/unit/parse_file_spec.rb
@@ -26,6 +26,14 @@ describe GitHubChangelogGenerator::ParserFile do
       it { expect { parser.parse! }.to raise_error(/line #2/) }
     end
 
+    context "allows comments with semi-colon or pound sign" do
+      let(:file) { StringIO.new("# Comment on first line\nunreleased_label=staging\n; Comment on third line\nunreleased=false") }
+      let(:parser) do
+        GitHubChangelogGenerator::ParserFile.new({}, file)
+      end
+      it { expect { parser.parse! }.not_to raise_error }
+    end
+
     context "when override default values" do
       let(:default_options) { GitHubChangelogGenerator::Parser.default_options }
       let(:options) { {}.merge(default_options) }

--- a/spec/unit/parse_file_spec.rb
+++ b/spec/unit/parse_file_spec.rb
@@ -1,14 +1,14 @@
 describe GitHubChangelogGenerator::ParserFile do
   describe ".github_changelog_generator" do
-    context "when no has file" do
-      let(:options) { {} }
+    let(:options) { {} }
+
+    context "when the well-known default file does not exist" do
       let(:parser) { GitHubChangelogGenerator::ParserFile.new(options) }
       subject { parser.parse! }
       it { is_expected.to be_nil }
     end
 
     context "when file is empty" do
-      let(:options) { {} }
       let(:parser) { GitHubChangelogGenerator::ParserFile.new(options, StringIO.new("")) }
 
       it "does not change the options" do
@@ -17,7 +17,6 @@ describe GitHubChangelogGenerator::ParserFile do
     end
 
     context "when file is incorrect" do
-      let(:options) { {} }
       let(:options_before_change) { options.dup }
       let(:file) { StringIO.new("unreleased_label=staging\nunreleased: false") }
       let(:parser) do
@@ -29,7 +28,7 @@ describe GitHubChangelogGenerator::ParserFile do
     context "allows comments with semi-colon or pound sign" do
       let(:file) { StringIO.new("# Comment on first line\nunreleased_label=staging\n; Comment on third line\nunreleased=false") }
       let(:parser) do
-        GitHubChangelogGenerator::ParserFile.new({}, file)
+        GitHubChangelogGenerator::ParserFile.new(options, file)
       end
       it { expect { parser.parse! }.not_to raise_error }
     end


### PR DESCRIPTION
- Ruby-style or semi-colon-style accepted in the `.github_changelog_generator` settings file.

Other non-setting-like lines are still reported as failures to parse.