### PR TITLE
Replace shelling-out-to-Git w/ Dir call

### DIFF
--- a/github_changelog_generator.gemspec
+++ b/github_changelog_generator.gemspec
@@ -18,7 +18,8 @@ Gem::Specification.new do |spec|
   spec.license = "MIT"
   spec.extensions = ["Rakefile"]
 
-  spec.files = `git ls-files -z`.split("\x0")
+  spec.files = Dir['{bin,lib,man,spec}/**/*', 'Rakefile', 'README.md']
+
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]


### PR DESCRIPTION
When the user's PATH does not include `git`, the gemspec becomes unusable.

Using Ruby instead avoids this problem.

See #349 
