### PR TITLE
Fixes for Tag handling

### DIFF
--- a/lib/github_changelog_generator/generator/generator.rb
+++ b/lib/github_changelog_generator/generator/generator.rb
@@ -10,7 +10,7 @@ module GitHubChangelogGenerator
   end
 
   class Generator
-    attr_accessor :options, :filtered_tags, :github
+    attr_accessor :options, :filtered_tags, :github, :tag_section_mapping
 
     # A Generator responsible for all logic, related with change log generation from ready-to-parse issues
     #

--- a/lib/github_changelog_generator/generator/generator_fetcher.rb
+++ b/lib/github_changelog_generator/generator/generator_fetcher.rb
@@ -12,13 +12,13 @@ module GitHubChangelogGenerator
     end
 
     # Async fetching of all tags dates
-    def fetch_tags_dates
+    def fetch_tags_dates(tags)
       print "Fetching tag dates...\r" if @options[:verbose]
       # Async fetching tags:
       threads = []
       i = 0
-      all = @filtered_tags.count
-      @filtered_tags.each do |tag|
+      all = tags.count
+      tags.each do |tag|
         print "                                 \r"
         threads << Thread.new do
           get_time_of_tag(tag)

--- a/lib/github_changelog_generator/generator/generator_generation.rb
+++ b/lib/github_changelog_generator/generator/generator_generation.rb
@@ -137,7 +137,7 @@ module GitHubChangelogGenerator
 
       log = generate_unreleased_section
 
-      @tag_section_mapping.each_pair do |tag_section, left_right_tags|
+      @tag_section_mapping.each_pair do |_tag_section, left_right_tags|
         older_tag, newer_tag = left_right_tags
         log += generate_log_between_tags(older_tag, newer_tag)
       end

--- a/lib/github_changelog_generator/generator/generator_generation.rb
+++ b/lib/github_changelog_generator/generator/generator_generation.rb
@@ -141,12 +141,6 @@ module GitHubChangelogGenerator
         older_tag, newer_tag = left_right_tags
         log += generate_log_between_tags(older_tag, newer_tag)
       end
-      # (1...filtered_tags.size).each do |index|
-      #   log += generate_log_between_tags(filtered_tags[index], filtered_tags[index - 1])
-      # end
-      # if @filtered_tags.count != 0
-      #   log += generate_log_between_tags(nil, filtered_tags.last)
-      # end
 
       log
     end

--- a/lib/github_changelog_generator/generator/generator_generation.rb
+++ b/lib/github_changelog_generator/generator/generator_generation.rb
@@ -5,7 +5,6 @@ module GitHubChangelogGenerator
     # @return [String] Generated change log file
     def compound_changelog
       fetch_and_filter_tags
-      sort_tags_by_date(@filtered_tags)
       fetch_issues_and_pr
 
       log = ""
@@ -138,12 +137,16 @@ module GitHubChangelogGenerator
 
       log = generate_unreleased_section
 
-      (1...filtered_tags.size).each do |index|
-        log += generate_log_between_tags(filtered_tags[index], filtered_tags[index - 1])
+      @tag_section_mapping.each_pair do |tag_section, left_right_tags|
+        older_tag, newer_tag = left_right_tags
+        log += generate_log_between_tags(older_tag, newer_tag)
       end
-      if @filtered_tags.count != 0
-        log += generate_log_between_tags(nil, filtered_tags.last)
-      end
+      # (1...filtered_tags.size).each do |index|
+      #   log += generate_log_between_tags(filtered_tags[index], filtered_tags[index - 1])
+      # end
+      # if @filtered_tags.count != 0
+      #   log += generate_log_between_tags(nil, filtered_tags.last)
+      # end
 
       log
     end

--- a/lib/github_changelog_generator/generator/generator_tags.rb
+++ b/lib/github_changelog_generator/generator/generator_tags.rb
@@ -6,9 +6,10 @@ module GitHubChangelogGenerator
       detect_due_tag
 
       all_tags = @fetcher.get_all_tags
-      fetch_tags_dates(all_tags)       # Creates a Hash @tag_times_hash
-      sorted_tags = sort_tags_by_date(all_tags)
-      @filtered_tags = get_filtered_tags(sorted_tags)
+      fetch_tags_dates(all_tags) # Creates a Hash @tag_times_hash
+      sorted_tags          = sort_tags_by_date(all_tags)
+      @filtered_tags       = get_filtered_tags(sorted_tags)
+
       @tag_section_mapping = build_tag_section_mapping(@filtered_tags, all_tags)
 
       @filtered_tags

--- a/lib/github_changelog_generator/generator/generator_tags.rb
+++ b/lib/github_changelog_generator/generator/generator_tags.rb
@@ -5,12 +5,14 @@ module GitHubChangelogGenerator
       detect_since_tag
       detect_due_tag
 
-      all_tags = @fetcher.get_all_tags
-      fetch_tags_dates(all_tags) # Creates a Hash @tag_times_hash
-      sorted_tags          = sort_tags_by_date(all_tags)
-      @filtered_tags       = get_filtered_tags(sorted_tags)
+      all_tags      = @fetcher.get_all_tags
+      included_tags = filter_excluded_tags(all_tags)
 
-      @tag_section_mapping = build_tag_section_mapping(@filtered_tags, all_tags)
+      fetch_tags_dates(all_tags) # Creates a Hash @tag_times_hash
+      sorted_tags          = sort_tags_by_date(included_tags)
+      @filtered_tags       = get_filtered_tags(included_tags)
+
+      @tag_section_mapping = build_tag_section_mapping(@filtered_tags, sorted_tags)
 
       @filtered_tags
     end
@@ -97,8 +99,7 @@ module GitHubChangelogGenerator
     def get_filtered_tags(all_tags)
       filtered_tags = filter_since_tag(all_tags)
       filtered_tags = filter_due_tag(filtered_tags)
-      filtered_tags = filter_between_tags(filtered_tags)
-      filter_excluded_tags(filtered_tags)
+      filter_between_tags(filtered_tags)
     end
 
     # @param [Array] all_tags all tags

--- a/lib/github_changelog_generator/generator/generator_tags.rb
+++ b/lib/github_changelog_generator/generator/generator_tags.rb
@@ -7,17 +7,9 @@ module GitHubChangelogGenerator
 
       all_tags = @fetcher.get_all_tags
       fetch_tags_dates(all_tags)       # Creates a Hash @tag_times_hash
-
       sorted_tags = sort_tags_by_date(all_tags)
       @filtered_tags = get_filtered_tags(sorted_tags)
-
-      puts "FILTERED TAGS: "
-      puts @filtered_tags.inspect
-
       @tag_section_mapping = build_tag_section_mapping(@filtered_tags, all_tags)
-
-      puts "TAG SECTION MAPPING"
-      puts @tag_section_mapping.inspect
 
       @filtered_tags
     end

--- a/spec/unit/generator/generator_tags_spec.rb
+++ b/spec/unit/generator/generator_tags_spec.rb
@@ -64,7 +64,7 @@ describe GitHubChangelogGenerator::Generator do
     context "with excluded and between tags" do
       let(:generator) { GitHubChangelogGenerator::Generator.new(between_tags: %w(1 2 3), exclude_tags: %w(2)) }
       it { is_expected.to be_a Array }
-      it { is_expected.to match_array(tags_mash_from_strings(%w(1 3))) }
+      it { is_expected.to match_array(tags_mash_from_strings(%w(1 2 3))) }
     end
   end
 


### PR DESCRIPTION
Main problem is that previously, it would put all PRs into the newest Tag section.
The reason is because the since_tag would be detected as nil, so it would include all tags from the beginning of time. I changed the logic to make a hash, with:
key: tag to make section
value: [left-tag, right-tag]

Now, we iterate through this hash, and create sections for each, choosing the PRs committed between left-tag date and right-tag date.




Related to:
https://github.com/skywinder/github-changelog-generator/issues/365

https://github.com/skywinder/github-changelog-generator/issues/304

https://github.com/skywinder/github-changelog-generator/issues/282