### PR TITLE
Make error messages print on error

### DIFF
--- a/lib/github_changelog_generator/fetcher.rb
+++ b/lib/github_changelog_generator/fetcher.rb
@@ -52,10 +52,10 @@ module GitHubChangelogGenerator
       begin
         value = yield
       rescue Github::Error::Unauthorized => e
-        Helper.log.error e.body.red
+        Helper.log.warn e.error_messages.map { |m| m[:message] }.join(", ").red
         abort "Error: wrong GitHub token"
       rescue Github::Error::Forbidden => e
-        Helper.log.warn e.body.red
+        Helper.log.warn e.error_messages.map { |m| m[:message] }.join(", ").red
         Helper.log.warn GH_RATE_LIMIT_EXCEEDED_MSG.yellow
       end
       value


### PR DESCRIPTION
When you get a rate limit error, github-changelog-generator presently raises an error that doesn't tell you what's going on:

```
/usr/local/var/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/github_changelog_generator-1.13.1/lib/github_changelog_generator/fetcher.rb:59:in `rescue in check_github_response': undefined method `body' for #<Github::Error::Forbidden:0x007fe6999b9268> (NoMethodError)
```

This patch rectifies that and uses `e.error_messages`, which prints:

```
API rate limit exceeded for jkeiser.
See: https://developer.github.com/v3/#rate-limiting
```