### PR TITLE
Replace GPL'd colorize gem with MIT-licensed rainbow

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     github_changelog_generator (1.13.1)
-      colorize (>= 0.7)
+      rainbow (>= 2.1)
       github_api (>= 0.12)
       rake (>= 10.0)
 
@@ -15,7 +15,6 @@ GEM
       ffi (~> 1.0, >= 1.0.11)
     codeclimate-test-reporter (0.6.0)
       simplecov (>= 0.7.1, < 1.0.0)
-    colorize (0.8.1)
     coveralls (0.8.14)
       json (>= 1.8, < 3)
       simplecov (~> 0.12.0)

--- a/github_changelog_generator.gemspec
+++ b/github_changelog_generator.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "rake", ">= 10.0"
   spec.add_runtime_dependency "github_api", ">= 0.12"
-  spec.add_runtime_dependency "colorize", ">= 0.7"
+  spec.add_runtime_dependency "rainbow", ">= 2.1"
 
   spec.add_development_dependency "overcommit", ">= 0.31"
   spec.add_development_dependency "rspec", ">= 3.2"

--- a/lib/github_changelog_generator.rb
+++ b/lib/github_changelog_generator.rb
@@ -2,7 +2,7 @@
 
 require "github_api"
 require "json"
-require "colorize"
+require "rainbow/ext/string"
 require "benchmark"
 
 require_relative "github_changelog_generator/helper"

--- a/lib/github_changelog_generator.rb
+++ b/lib/github_changelog_generator.rb
@@ -2,7 +2,6 @@
 
 require "github_api"
 require "json"
-require "rainbow/ext/string"
 require "benchmark"
 
 require_relative "github_changelog_generator/helper"

--- a/lib/github_changelog_generator/fetcher.rb
+++ b/lib/github_changelog_generator/fetcher.rb
@@ -34,7 +34,7 @@ module GitHubChangelogGenerator
     def fetch_github_token
       env_var = @options[:token] ? @options[:token] : (ENV.fetch CHANGELOG_GITHUB_TOKEN, nil)
 
-      Helper.log.warn NO_TOKEN_PROVIDED.color(:yellow) unless env_var
+      Helper.log.warn NO_TOKEN_PROVIDED unless env_var
 
       env_var
     end
@@ -53,11 +53,11 @@ module GitHubChangelogGenerator
       begin
         value = yield
       rescue Github::Error::Unauthorized => e
-        Helper.log.error e.response_message.color(:red)
+        Helper.log.error e.response_message
         abort "Error: wrong GitHub token"
       rescue Github::Error::Forbidden => e
-        Helper.log.warn e.response_message.color(:red)
-        Helper.log.warn GH_RATE_LIMIT_EXCEEDED_MSG.color(:yellow)
+        Helper.log.warn e.response_message
+        Helper.log.warn GH_RATE_LIMIT_EXCEEDED_MSG
       end
       value
     end
@@ -76,9 +76,9 @@ module GitHubChangelogGenerator
       end
       print_empty_line
 
-      if tags.count == 0
+      if tags.empty?
         Helper.log.warn "Warning: Can't find any tags in repo.\
-Make sure, that you push tags to remote repo via 'git push --tags'".color(:yellow)
+Make sure, that you push tags to remote repo via 'git push --tags'"
       else
         Helper.log.info "Found #{tags.count} tags"
       end
@@ -110,8 +110,8 @@ Make sure, that you push tags to remote repo via 'git push --tags'".color(:yello
         Helper.log.info "Received issues: #{issues.count}"
 
       rescue Github::Error::Forbidden => e
-        Helper.log.warn e.error_messages.map { |m| m[:message] }.join(", ").color(:red)
-        Helper.log.warn GH_RATE_LIMIT_EXCEEDED_MSG.color(:yellow)
+        Helper.log.warn e.error_messages.map { |m| m[:message] }.join(", ")
+        Helper.log.warn GH_RATE_LIMIT_EXCEEDED_MSG
       end
 
       # separate arrays of issues and pull requests:
@@ -145,8 +145,8 @@ Make sure, that you push tags to remote repo via 'git push --tags'".color(:yello
         end
         print_empty_line
       rescue Github::Error::Forbidden => e
-        Helper.log.warn e.error_messages.map { |m| m[:message] }.join(", ").color(:red)
-        Helper.log.warn GH_RATE_LIMIT_EXCEEDED_MSG.color(:yellow)
+        Helper.log.warn e.error_messages.map { |m| m[:message] }.join(", ")
+        Helper.log.warn GH_RATE_LIMIT_EXCEEDED_MSG
       end
 
       Helper.log.info "Fetching merged dates: #{pull_requests.count}"
@@ -182,8 +182,8 @@ Make sure, that you push tags to remote repo via 'git push --tags'".color(:yello
                 issue[:events].concat(page)
               end
             rescue Github::Error::Forbidden => e
-              Helper.log.warn e.error_messages.map { |m| m[:message] }.join(", ").color(:red)
-              Helper.log.warn GH_RATE_LIMIT_EXCEEDED_MSG.color(:yellow)
+              Helper.log.warn e.error_messages.map { |m| m[:message] }.join(", ")
+              Helper.log.warn GH_RATE_LIMIT_EXCEEDED_MSG
             end
             print_in_same_line("Fetching events for issues and PR: #{i + 1}/#{issues.count}")
             i += 1
@@ -209,8 +209,8 @@ Make sure, that you push tags to remote repo via 'git push --tags'".color(:yello
                                                    @options[:project],
                                                    tag["commit"]["sha"]
       rescue Github::Error::Forbidden => e
-        Helper.log.warn e.error_messages.map { |m| m[:message] }.join(", ").color(:red)
-        Helper.log.warn GH_RATE_LIMIT_EXCEEDED_MSG.color(:yellow)
+        Helper.log.warn e.error_messages.map { |m| m[:message] }.join(", ")
+        Helper.log.warn GH_RATE_LIMIT_EXCEEDED_MSG
       end
       time_string = commit_data["committer"]["date"]
       Time.parse(time_string)

--- a/lib/github_changelog_generator/fetcher.rb
+++ b/lib/github_changelog_generator/fetcher.rb
@@ -34,7 +34,7 @@ module GitHubChangelogGenerator
     def fetch_github_token
       env_var = @options[:token] ? @options[:token] : (ENV.fetch CHANGELOG_GITHUB_TOKEN, nil)
 
-      Helper.log.warn NO_TOKEN_PROVIDED.yellow unless env_var
+      Helper.log.warn NO_TOKEN_PROVIDED.color(:yellow) unless env_var
 
       env_var
     end
@@ -53,11 +53,11 @@ module GitHubChangelogGenerator
       begin
         value = yield
       rescue Github::Error::Unauthorized => e
-        Helper.log.error e.response_message.red
+        Helper.log.error e.response_message.color(:red)
         abort "Error: wrong GitHub token"
       rescue Github::Error::Forbidden => e
-        Helper.log.warn e.response_message.red
-        Helper.log.warn GH_RATE_LIMIT_EXCEEDED_MSG.yellow
+        Helper.log.warn e.response_message.color(:red)
+        Helper.log.warn GH_RATE_LIMIT_EXCEEDED_MSG.color(:yellow)
       end
       value
     end
@@ -78,7 +78,7 @@ module GitHubChangelogGenerator
 
       if tags.count == 0
         Helper.log.warn "Warning: Can't find any tags in repo.\
-Make sure, that you push tags to remote repo via 'git push --tags'".yellow
+Make sure, that you push tags to remote repo via 'git push --tags'".color(:yellow)
       else
         Helper.log.info "Found #{tags.count} tags"
       end
@@ -110,8 +110,8 @@ Make sure, that you push tags to remote repo via 'git push --tags'".yellow
         Helper.log.info "Received issues: #{issues.count}"
 
       rescue Github::Error::Forbidden => e
-        Helper.log.warn e.error_messages.map { |m| m[:message] }.join(", ").red
-        Helper.log.warn GH_RATE_LIMIT_EXCEEDED_MSG.yellow
+        Helper.log.warn e.error_messages.map { |m| m[:message] }.join(", ").color(:red)
+        Helper.log.warn GH_RATE_LIMIT_EXCEEDED_MSG.color(:yellow)
       end
 
       # separate arrays of issues and pull requests:
@@ -145,8 +145,8 @@ Make sure, that you push tags to remote repo via 'git push --tags'".yellow
         end
         print_empty_line
       rescue Github::Error::Forbidden => e
-        Helper.log.warn e.error_messages.map { |m| m[:message] }.join(", ").red
-        Helper.log.warn GH_RATE_LIMIT_EXCEEDED_MSG.yellow
+        Helper.log.warn e.error_messages.map { |m| m[:message] }.join(", ").color(:red)
+        Helper.log.warn GH_RATE_LIMIT_EXCEEDED_MSG.color(:yellow)
       end
 
       Helper.log.info "Fetching merged dates: #{pull_requests.count}"
@@ -182,8 +182,8 @@ Make sure, that you push tags to remote repo via 'git push --tags'".yellow
                 issue[:events].concat(page)
               end
             rescue Github::Error::Forbidden => e
-              Helper.log.warn e.error_messages.map { |m| m[:message] }.join(", ").red
-              Helper.log.warn GH_RATE_LIMIT_EXCEEDED_MSG.yellow
+              Helper.log.warn e.error_messages.map { |m| m[:message] }.join(", ").color(:red)
+              Helper.log.warn GH_RATE_LIMIT_EXCEEDED_MSG.color(:yellow)
             end
             print_in_same_line("Fetching events for issues and PR: #{i + 1}/#{issues.count}")
             i += 1
@@ -209,8 +209,8 @@ Make sure, that you push tags to remote repo via 'git push --tags'".yellow
                                                    @options[:project],
                                                    tag["commit"]["sha"]
       rescue Github::Error::Forbidden => e
-        Helper.log.warn e.error_messages.map { |m| m[:message] }.join(", ").red
-        Helper.log.warn GH_RATE_LIMIT_EXCEEDED_MSG.yellow
+        Helper.log.warn e.error_messages.map { |m| m[:message] }.join(", ").color(:red)
+        Helper.log.warn GH_RATE_LIMIT_EXCEEDED_MSG.color(:yellow)
       end
       time_string = commit_data["committer"]["date"]
       Time.parse(time_string)

--- a/lib/github_changelog_generator/generator/generator_fetcher.rb
+++ b/lib/github_changelog_generator/generator/generator_fetcher.rb
@@ -74,7 +74,7 @@ module GitHubChangelogGenerator
           commit = @fetcher.fetch_commit(event)
           issue[:actual_date] = commit[:author][:date]
         rescue
-          puts "Warning: Can't fetch commit #{event[:commit_id]}. It is probably referenced from another repo.".yellow
+          puts "Warning: Can't fetch commit #{event[:commit_id]}. It is probably referenced from another repo.".color(:yellow)
           issue[:actual_date] = issue[:closed_at]
         end
       end

--- a/lib/github_changelog_generator/generator/generator_fetcher.rb
+++ b/lib/github_changelog_generator/generator/generator_fetcher.rb
@@ -74,7 +74,7 @@ module GitHubChangelogGenerator
           commit = @fetcher.fetch_commit(event)
           issue[:actual_date] = commit[:author][:date]
         rescue
-          puts "Warning: Can't fetch commit #{event[:commit_id]}. It is probably referenced from another repo.".color(:yellow)
+          puts "Warning: Can't fetch commit #{event[:commit_id]}. It is probably referenced from another repo."
           issue[:actual_date] = issue[:closed_at]
         end
       end

--- a/lib/github_changelog_generator/generator/generator_generation.rb
+++ b/lib/github_changelog_generator/generator/generator_generation.rb
@@ -39,10 +39,10 @@ module GitHubChangelogGenerator
           index2 = hash[tag2]
           log += generate_log_between_tags(all_tags[index1], all_tags[index2])
         else
-          raise ChangelogGeneratorError, "Can't find tag #{tag2} -> exit".red
+          raise ChangelogGeneratorError, "Can't find tag #{tag2} -> exit".color(:red)
         end
       else
-        raise ChangelogGeneratorError, "Can't find tag #{tag1} -> exit".red
+        raise ChangelogGeneratorError, "Can't find tag #{tag1} -> exit".color(:red)
       end
       log
     end

--- a/lib/github_changelog_generator/generator/generator_generation.rb
+++ b/lib/github_changelog_generator/generator/generator_generation.rb
@@ -39,10 +39,10 @@ module GitHubChangelogGenerator
           index2 = hash[tag2]
           log += generate_log_between_tags(all_tags[index1], all_tags[index2])
         else
-          raise ChangelogGeneratorError, "Can't find tag #{tag2} -> exit".color(:red)
+          raise ChangelogGeneratorError, "Can't find tag #{tag2} -> exit"
         end
       else
-        raise ChangelogGeneratorError, "Can't find tag #{tag1} -> exit".color(:red)
+        raise ChangelogGeneratorError, "Can't find tag #{tag1} -> exit"
       end
       log
     end
@@ -141,7 +141,7 @@ module GitHubChangelogGenerator
       (1...filtered_tags.size).each do |index|
         log += generate_log_between_tags(filtered_tags[index], filtered_tags[index - 1])
       end
-      if @filtered_tags.count != 0
+      if filtered_tags.any?
         log += generate_log_between_tags(nil, filtered_tags.last)
       end
 

--- a/lib/github_changelog_generator/generator/generator_tags.rb
+++ b/lib/github_changelog_generator/generator/generator_tags.rb
@@ -19,7 +19,7 @@ module GitHubChangelogGenerator
     # @param [Hash] tag_name name of the tag
     # @return [Time] time of specified tag
     def get_time_of_tag(tag_name)
-      raise ChangelogGeneratorError, "tag_name is nil".color(:red) if tag_name.nil?
+      raise ChangelogGeneratorError, "tag_name is nil" if tag_name.nil?
 
       name_of_tag = tag_name["name"]
       time_for_name = @tag_times_hash[name_of_tag]
@@ -99,7 +99,7 @@ module GitHubChangelogGenerator
       filtered_tags = all_tags
       tag = @options[:due_tag]
       if tag
-        if (all_tags.count > 0) && (all_tags.map(&:name).include? tag)
+        if all_tags.any? && all_tags.map(&:name).include?(tag)
           idx = all_tags.index { |t| t.name == tag }
           last_index = all_tags.count - 1
           filtered_tags = if idx > 0 && idx < last_index

--- a/lib/github_changelog_generator/generator/generator_tags.rb
+++ b/lib/github_changelog_generator/generator/generator_tags.rb
@@ -19,7 +19,7 @@ module GitHubChangelogGenerator
     # @param [Hash] tag_name name of the tag
     # @return [Time] time of specified tag
     def get_time_of_tag(tag_name)
-      raise ChangelogGeneratorError, "tag_name is nil".red if tag_name.nil?
+      raise ChangelogGeneratorError, "tag_name is nil".color(:red) if tag_name.nil?
 
       name_of_tag = tag_name["name"]
       time_for_name = @tag_times_hash[name_of_tag]

--- a/lib/github_changelog_generator/helper.rb
+++ b/lib/github_changelog_generator/helper.rb
@@ -15,15 +15,15 @@ module GitHubChangelogGenerator
       string = "#{msg}\n"
 
       if severity == "DEBUG"
-        string = string.magenta
+        string = string.color(:magenta)
       elsif severity == "INFO"
-        string = string.white
+        string = string.color(:white)
       elsif severity == "WARN"
-        string = string.yellow
+        string = string.color(:yellow)
       elsif severity == "ERROR"
-        string = string.red
+        string = string.color(:red)
       elsif severity == "FATAL"
-        string = string.red.bold
+        string = string.color(:red).bright
       end
 
       string

--- a/lib/github_changelog_generator/helper.rb
+++ b/lib/github_changelog_generator/helper.rb
@@ -1,4 +1,6 @@
 require "logger"
+require "rainbow/ext/string"
+
 module GitHubChangelogGenerator
   module Helper
     # @return true if the currently running program is a unit test
@@ -13,20 +15,14 @@ module GitHubChangelogGenerator
              end
     @log.formatter = proc do |severity, _datetime, _progname, msg|
       string = "#{msg}\n"
-
-      if severity == "DEBUG"
-        string = string.color(:magenta)
-      elsif severity == "INFO"
-        string = string.color(:white)
-      elsif severity == "WARN"
-        string = string.color(:yellow)
-      elsif severity == "ERROR"
-        string = string.color(:red)
-      elsif severity == "FATAL"
-        string = string.color(:red).bright
+      case severity
+      when "DEBUG" then string.color(:magenta)
+      when "INFO" then string.color(:white)
+      when "WARN" then string.color(:yellow)
+      when "ERROR" then string.color(:red)
+      when "FATAL" then string.color(:red).bright
+      else string
       end
-
-      string
     end
 
     # Logging happens using this method

--- a/lib/github_changelog_generator/helper.rb
+++ b/lib/github_changelog_generator/helper.rb
@@ -1,5 +1,5 @@
 require "logger"
-require "rainbow/ext/string"
+require "rainbow"
 
 module GitHubChangelogGenerator
   module Helper
@@ -16,11 +16,11 @@ module GitHubChangelogGenerator
     @log.formatter = proc do |severity, _datetime, _progname, msg|
       string = "#{msg}\n"
       case severity
-      when "DEBUG" then string.color(:magenta)
-      when "INFO" then string.color(:white)
-      when "WARN" then string.color(:yellow)
-      when "ERROR" then string.color(:red)
-      when "FATAL" then string.color(:red).bright
+      when "DEBUG" then Rainbow(string).magenta
+      when "INFO" then Rainbow(string).white
+      when "WARN" then Rainbow(string).yellow
+      when "ERROR" then Rainbow(string).red
+      when "FATAL" then Rainbow(string).red.bright
       else string
       end
     end


### PR DESCRIPTION
colorize is licensed under GPL-2 which conflicts with the MIT license of
github_changelog_generator.  This changes all usage of colorize to
rainbow which does have a compatible license (MIT)