### PR TITLE
Spec: avoid Ruby warning about already-defined constant

### DIFF
--- a/spec/unit/parser_spec.rb
+++ b/spec/unit/parser_spec.rb
@@ -63,9 +63,10 @@ describe GitHubChangelogGenerator::Parser do
     end
   end
   describe ".fetch_user_and_project" do
-    before :each do
-      ARGV = ["https://github.com/skywinder/github-changelog-generator"]
+    before do
+      stub_const("ARGV", ["https://github.com/skywinder/github-changelog-generator"])
     end
+
     context do
       let(:valid_user) { "initialized_user" }
       let(:options) { { user: valid_user } }


### PR DESCRIPTION
Using RSpec [`stub_const`](https://relishapp.com/rspec/rspec-mocks/docs/mutating-constants/stub-defined-constant), this PR avoids a printed warning every spec run.

With this change, the CircleCI current "progress"-formatted RSpec output looks like:

```
..../home/ubuntu/github-changelog-generator/vendor/bundle/ruby/1.9.1/gems/github_api-0.14.4/lib/github_api/ext/faraday.rb:11: warning: instance variable @encoder not initialized
.........................................................Can't detect user and name from first parameter: 'blah' -> exit'
............................................*.........
```

Which is less output than before.