### PR TITLE
Travis: use Ruby 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ before_install:
   - gem update --system
   - gem install bundler
 rvm:
-  - 2.1
+  - 2.2
 script: bundle exec rake checks
 matrix:
   include:


### PR DESCRIPTION
Rack 2.x isn't installable on any ruby less than 2.2.2, it says.

This PR tentatively tries to use the rvm version "2.2" at Travis, to see whether this allows the rake-based installation tests to pass.

**Update**: no, that's squarely 2.2.0, not 2.2.2.

The error:

```
Fetching: rack-2.0.1.gem (100%)
ERROR:  Error installing github_changelog_generator-1.13.1.gem:
	rack requires Ruby version >= 2.2.2.
```
