### PR TITLE
Pull Requests compared using the merged_at field - credit: Abonas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,5 @@
 # Change Log
 
-## [Unreleased](https://github.com/skywinder/github-changelog-generator/tree/HEAD)
-
-[Full Changelog](https://github.com/skywinder/github-changelog-generator/compare/1.7.0...HEAD)
-
-**Merged pull requests:**
-
-- Add a rake task [\#260](https://github.com/skywinder/github-changelog-generator/pull/260) ([raphink](https://github.com/raphink))
-- Add release\_url option [\#259](https://github.com/skywinder/github-changelog-generator/pull/259) ([raphink](https://github.com/raphink))
-- Add --since-tag, close  [\#257](https://github.com/skywinder/github-changelog-generator/pull/257) ([raphink](https://github.com/raphink))
-
 ## [1.7.0](https://github.com/skywinder/github-changelog-generator/tree/1.7.0) (2015-07-16)
 [Full Changelog](https://github.com/skywinder/github-changelog-generator/compare/1.6.2...1.7.0)
 

--- a/lib/github_changelog_generator/generator/generator_generation.rb
+++ b/lib/github_changelog_generator/generator/generator_generation.rb
@@ -115,7 +115,7 @@ module GitHubChangelogGenerator
     #
     # @return [Array] filtered issues and pull requests
     def filter_issues_for_tags(newer_tag, older_tag)
-      filtered_pull_requests = delete_by_time(@pull_requests, :actual_date, older_tag, newer_tag)
+      filtered_pull_requests = delete_by_time(@pull_requests, :merged_at, older_tag, newer_tag)
       filtered_issues = delete_by_time(@issues, :actual_date, older_tag, newer_tag)
 
       newer_tag_name = newer_tag.nil? ? nil : newer_tag["name"]


### PR DESCRIPTION
This PR changes date comparisons to be about `merged_at` instead of the current `actual_date` field.