### PR TITLE
Add option to show selected labels in the issue line

### DIFF
--- a/lib/github_changelog_generator/generator/generator_generation.rb
+++ b/lib/github_changelog_generator/generator/generator_generation.rb
@@ -25,7 +25,7 @@ module GitHubChangelogGenerator
     end
 
     # @param [Array] issues List of issues on sub-section
-    # @param [String] prefix Nae of sub-section
+    # @param [String] prefix Name of sub-section
     # @return [String] Generate ready-to-go sub-section
     def generate_sub_section(issues, prefix)
       log = ""
@@ -143,10 +143,22 @@ module GitHubChangelogGenerator
       encapsulated_title = encapsulate_string issue["title"]
 
       title_with_number = "#{encapsulated_title} [\\##{issue['number']}](#{issue['html_url']})"
+      if options[:issue_line_labels].present?
+        title_with_number = "#{title_with_number}{line_labels_for(issue)}"
+      end
       issue_line_with_user(title_with_number, issue)
     end
 
     private
+
+    def line_labels_for(issue)
+      labels = if options[:issue_line_labels] == ["ALL"]
+                 issue["labels"]
+               else
+                 issue["labels"].select { |label| options[:issue_line_labels].include?(label["name"]) }
+               end
+      labels.map { |label| " \[[#{label['name']}](#{label['url'].sub('api.github.com/repos', 'github.com')})\]" }.join("")
+    end
 
     def issue_line_with_user(line, issue)
       return line if !options[:author] || issue["pull_request"].nil?

--- a/lib/github_changelog_generator/options.rb
+++ b/lib/github_changelog_generator/options.rb
@@ -32,6 +32,7 @@ module GitHubChangelogGenerator
       :http_cache,
       :include_labels,
       :issue_prefix,
+      :issue_line_labels,
       :issues,
       :max_issues,
       :merge_prefix,

--- a/lib/github_changelog_generator/parser.rb
+++ b/lib/github_changelog_generator/parser.rb
@@ -125,6 +125,9 @@ module GitHubChangelogGenerator
         opts.on("--enhancement-labels  x,y,z", Array, 'Issues with the specified labels will be always added to "Implemented enhancements" section. Default is \'enhancement,Enhancement\'') do |list|
           options[:enhancement_labels] = list
         end
+        opts.on("--issue-line-labels x,y,z", Array, 'The specified labels will be shown in brackets next to each matching issue. Use "ALL" to show all labels. Default is [].') do |list|
+          options[:issue_line_labels] = list
+        end
         opts.on("--between-tags  x,y,z", Array, "Change log will be filled only between specified tags") do |list|
           options[:between_tags] = list
         end
@@ -205,6 +208,7 @@ module GitHubChangelogGenerator
         enhancement_labels: %w(enhancement Enhancement),
         bug_labels: %w(bug Bug),
         exclude_labels: %w(duplicate question invalid wontfix Duplicate Question Invalid Wontfix),
+        issue_line_labels: [],
         max_issues: nil,
         simple_list: false,
         verbose: true,

--- a/lib/github_changelog_generator/parser_file.rb
+++ b/lib/github_changelog_generator/parser_file.rb
@@ -66,7 +66,7 @@ module GitHubChangelogGenerator
     end
 
     KNOWN_ARRAY_KEYS = [:exclude_labels, :include_labels, :bug_labels,
-                        :enhancement_labels, :between_tags, :exclude_tags]
+                        :enhancement_labels, :issue_line_labels, :between_tags, :exclude_tags]
     KNOWN_INTEGER_KEYS = [:max_issues]
 
     def convert_value(value, option_name)


### PR DESCRIPTION
This adds an option, `--issue-line-labels`, which allows the user to list the specified Github labels, in brackets, next to each issue.

For example, when issue #367 of this repository is closed, the Changelog for that issue, with option  `--issue-line-labels=ALL` will look like this: 

- Feature Request: On using a public token on a private repo and getting a 404, fail informatively #367 [feature-request][first-timers-only][help-wanted]

Selected labels can be specified in the option:
`--issue-line-labels=first-timers-only` will generate the following line:
- Feature Request: On using a public token on a private repo and getting a 404, fail informatively #367 [first-timers-only]

Related to #316 