### PR TITLE
Skip logger helper in coverage

### DIFF
--- a/lib/github_changelog_generator/helper.rb
+++ b/lib/github_changelog_generator/helper.rb
@@ -9,6 +9,7 @@ module GitHubChangelogGenerator
       defined? SpecHelper
     end
 
+    # :nocov:
     @log ||= if test?
                Logger.new(nil) # don't show any logs when running tests
              else
@@ -25,6 +26,7 @@ module GitHubChangelogGenerator
       else string
       end
     end
+    # :nocov:
 
     # Logging happens using this method
     class << self


### PR DESCRIPTION
A trivial PR which removes the logger formatter from code coverage statistics.