### PR TITLE
Add bump gem to development deps

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,10 @@ group :development, :test do
   gem "rubocop", ">= 0.43"
 end
 
+group :development do
+  gem "bump"
+end
+
 group :test do
   gem "coveralls", "~>0.8", require: false
   gem "simplecov", "~>0.10", require: false


### PR DESCRIPTION
This PR adds the [bump](https://github.com/gregorym/bump) gem to the development section of the Gemfile.

This is meant to make it easier to automate releases more.