### PR TITLE
Travis: Add JRuby 9.1.5.0 to matrix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ doc
 .yardoc
 Gemfile.lock
 gemfiles/Gemfile.2_4_0.lock
+gemfiles/Gemfile.jruby-9.1.5.0.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,11 @@ matrix:
       gemfile: gemfiles/Gemfile.2_3_1
     - rvm: 2.4.0-preview2
       gemfile: gemfiles/Gemfile.2_4_0
+    - rvm: jruby-9.1.5.0
+      jdk: oraclejdk8
+      gemfile: gemfiles/Gemfile.jruby-9.1.5.0
+      env:
+        - JRUBY_OPTS=--debug
 
 notifications:
   email:

--- a/gemfiles/Gemfile.jruby-9.1.5.0
+++ b/gemfiles/Gemfile.jruby-9.1.5.0
@@ -1,0 +1,3 @@
+eval_gemfile File.expand_path('../../Gemfile', __FILE__)
+gem 'rack', '>= 2'
+


### PR DESCRIPTION
This PR tries to add latest JRuby to the list of supported Rubies.