### PR TITLE
Fix: Turn Sawyer method into String-keyed hash access

### DIFF
--- a/lib/github_changelog_generator/generator/generator_generation.rb
+++ b/lib/github_changelog_generator/generator/generator_generation.rb
@@ -149,7 +149,7 @@ module GitHubChangelogGenerator
     private
 
     def issue_line_with_user(line, issue)
-      return line if !options[:author] || issue.pull_request.nil?
+      return line if !options[:author] || issue["pull_request"].nil?
 
       user = issue["user"]
       return "#{line} ({Null user})" unless user


### PR DESCRIPTION
This PR fixes a typo in the OctoKit data usage.