### PR TITLE
On GitHub MAX_THREAD_NUMBER is 25

### DIFF
--- a/lib/github_changelog_generator/generator/generator_fetcher.rb
+++ b/lib/github_changelog_generator/generator/generator_fetcher.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 module GitHubChangelogGenerator
   class Generator
-    MAX_THREAD_NUMBER = 1
+    MAX_THREAD_NUMBER = 25
 
     # Fetch event for issues and pull requests
     # @return [Array] array of fetched issues

--- a/lib/github_changelog_generator/octo_fetcher.rb
+++ b/lib/github_changelog_generator/octo_fetcher.rb
@@ -7,7 +7,7 @@ module GitHubChangelogGenerator
   # fetcher = GitHubChangelogGenerator::OctoFetcher.new(options)
   class OctoFetcher
     PER_PAGE_NUMBER   = 100
-    MAX_THREAD_NUMBER = 1
+    MAX_THREAD_NUMBER = 25
     CHANGELOG_GITHUB_TOKEN = "CHANGELOG_GITHUB_TOKEN"
     GH_RATE_LIMIT_EXCEEDED_MSG = "Warning: Can't finish operation: GitHub API rate limit exceeded, change log may be " \
     "missing some issues. You can limit the number of issues fetched using the `--max-issues NUM` argument."


### PR DESCRIPTION
This PR adds back the MAX_THREAD_NUMBER to 25.

This makes the generation quick again.