### PR TITLE
man page: Add undescribed options

### DIFF
--- a/man/git-generate-changelog.1
+++ b/man/git-generate-changelog.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-GENERATE\-CHANGELOG" "1" "October 2015" "" ""
+.TH "GIT\-GENERATE\-CHANGELOG" "1" "November 2016" "" ""
 .
 .SH "NAME"
 \fBgit\-generate\-changelog\fR \- Generate changelog from github
@@ -73,6 +73,12 @@ Setup custom label for closed\-issues section\. Default is "\fBClosed issues:\fR
 Setup custom header label\. Default is "# Change Log"
 .
 .P
+\-\-front\-matter [JSON]
+.
+.P
+Add YAML front matter\. Formatted as JSON because it\'s easier to add on the command line
+.
+.P
 \-\-pr\-label [LABEL]
 .
 .P
@@ -113,6 +119,12 @@ Use milestone to detect when issue was resolved\. Default is true
 .
 .P
 Add author of pull\-request in the end\. Default is true
+.
+.P
+\-\-usernames\-as\-github\-logins
+.
+.P
+Use GitHub tags instead of Markdown links for the author of an issue or pull\-request\.
 .
 .P
 \-\-unreleased\-only
@@ -175,6 +187,12 @@ Change log will be filled only between specified tags
 Change log will exclude specified tags
 .
 .P
+\-\-exclude\-tags\-regex [REGEX]
+.
+.P
+Apply a regular expression on tag names so that they can be excluded, for example: \-\-exclude\-tags\-regex "\.*+\ed{1,}"
+.
+.P
 \-\-since\-tag x
 .
 .P
@@ -221,6 +239,30 @@ Create simple list from issues and pull requests\. Default is false\.
 .
 .P
 Put the unreleased changes in the specified release number\.
+.
+.P
+\-\-release\-branch [RELEASE\-BRANCH]
+.
+.P
+Limit pull requests to the release branch, such as master or release
+.
+.P
+\-\-http\-cache
+.
+.P
+Use HTTP Cache to cache Github API requests (useful for large repos) Default is true\.
+.
+.P
+\-\-[no\-]cache\-file [CACHE\-FILE]
+.
+.P
+Filename to use for cache\. Default is /tmp/github\-changelog\-http\-cache
+.
+.P
+\-\-cache\-log [CACHE\-LOG]
+.
+.P
+Filename to use for cache log\. Default is /tmp/github\-changelog\-logger\.log
 .
 .P
 \-\-[no\-]verbose

--- a/man/git-generate-changelog.1.html
+++ b/man/git-generate-changelog.1.html
@@ -1,0 +1,290 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv='content-type' value='text/html;charset=utf8'>
+  <meta name='generator' value='Ronn/v0.7.3 (http://github.com/rtomayko/ronn/tree/0.7.3)'>
+  <title>git-generate-changelog(1) - Generate changelog from github</title>
+  <style type='text/css' media='all'>
+  /* style: man */
+  body#manpage {margin:0}
+  .mp {max-width:100ex;padding:0 9ex 1ex 4ex}
+  .mp p,.mp pre,.mp ul,.mp ol,.mp dl {margin:0 0 20px 0}
+  .mp h2 {margin:10px 0 0 0}
+  .mp > p,.mp > pre,.mp > ul,.mp > ol,.mp > dl {margin-left:8ex}
+  .mp h3 {margin:0 0 0 4ex}
+  .mp dt {margin:0;clear:left}
+  .mp dt.flush {float:left;width:8ex}
+  .mp dd {margin:0 0 0 9ex}
+  .mp h1,.mp h2,.mp h3,.mp h4 {clear:left}
+  .mp pre {margin-bottom:20px}
+  .mp pre+h2,.mp pre+h3 {margin-top:22px}
+  .mp h2+pre,.mp h3+pre {margin-top:5px}
+  .mp img {display:block;margin:auto}
+  .mp h1.man-title {display:none}
+  .mp,.mp code,.mp pre,.mp tt,.mp kbd,.mp samp,.mp h3,.mp h4 {font-family:monospace;font-size:14px;line-height:1.42857142857143}
+  .mp h2 {font-size:16px;line-height:1.25}
+  .mp h1 {font-size:20px;line-height:2}
+  .mp {text-align:justify;background:#fff}
+  .mp,.mp code,.mp pre,.mp pre code,.mp tt,.mp kbd,.mp samp {color:#131211}
+  .mp h1,.mp h2,.mp h3,.mp h4 {color:#030201}
+  .mp u {text-decoration:underline}
+  .mp code,.mp strong,.mp b {font-weight:bold;color:#131211}
+  .mp em,.mp var {font-style:italic;color:#232221;text-decoration:none}
+  .mp a,.mp a:link,.mp a:hover,.mp a code,.mp a pre,.mp a tt,.mp a kbd,.mp a samp {color:#0000ff}
+  .mp b.man-ref {font-weight:normal;color:#434241}
+  .mp pre {padding:0 4ex}
+  .mp pre code {font-weight:normal;color:#434241}
+  .mp h2+pre,h3+pre {padding-left:0}
+  ol.man-decor,ol.man-decor li {margin:3px 0 10px 0;padding:0;float:left;width:33%;list-style-type:none;text-transform:uppercase;color:#999;letter-spacing:1px}
+  ol.man-decor {width:100%}
+  ol.man-decor li.tl {text-align:left}
+  ol.man-decor li.tc {text-align:center;letter-spacing:4px}
+  ol.man-decor li.tr {text-align:right;float:right}
+  </style>
+</head>
+<!--
+  The following styles are deprecated and will be removed at some point:
+  div#man, div#man ol.man, div#man ol.head, div#man ol.man.
+
+  The .man-page, .man-decor, .man-head, .man-foot, .man-title, and
+  .man-navigation should be used instead.
+-->
+<body id='manpage'>
+  <div class='mp' id='man'>
+
+  <div class='man-navigation' style='display:none'>
+    <a href="#NAME">NAME</a>
+    <a href="#SYNOPSIS">SYNOPSIS</a>
+    <a href="#DESCRIPTION">DESCRIPTION</a>
+    <a href="#OPTIONS">OPTIONS</a>
+    <a href="#EXAMPLES">EXAMPLES</a>
+    <a href="#AUTHOR">AUTHOR</a>
+    <a href="#REPORTING-BUGS">REPORTING BUGS</a>
+    <a href="#SEE-ALSO">SEE ALSO</a>
+  </div>
+
+  <ol class='man-decor man-head man head'>
+    <li class='tl'>git-generate-changelog(1)</li>
+    <li class='tc'></li>
+    <li class='tr'>git-generate-changelog(1)</li>
+  </ol>
+
+  <h2 id="NAME">NAME</h2>
+<p class="man-name">
+  <code>git-generate-changelog</code> - <span class="man-whatis">Generate changelog from github</span>
+</p>
+
+<h2 id="SYNOPSIS">SYNOPSIS</h2>
+
+<p><code>git generate-changelog</code> [-h|--help] [-u|--user] [-p|--project]</p>
+
+<h2 id="DESCRIPTION">DESCRIPTION</h2>
+
+<p>Automatically generate change log from your tags, issues, labels and pull requests on GitHub.</p>
+
+<h2 id="OPTIONS">OPTIONS</h2>
+
+<p>  -u, --user [USER]</p>
+
+<p>  Username of the owner of target GitHub repo</p>
+
+<p>  -p, --project [PROJECT]</p>
+
+<p>  Name of project on GitHub</p>
+
+<p>  -t, --token [TOKEN]</p>
+
+<p>  To make more than 50 requests per hour your GitHub token is required. You can generate it at: https://github.com/settings/tokens/new</p>
+
+<p>  -f, --date-format [FORMAT]</p>
+
+<p>  Date format. Default is %Y-%m-%d</p>
+
+<p>  -o, --output [NAME]</p>
+
+<p>  Output file. Default is CHANGELOG.md</p>
+
+<p>  -b, --base [NAME]</p>
+
+<p>  Optional base file to append generated changes to.</p>
+
+<p>   --bugs-label [LABEL]</p>
+
+<p>   Setup custom label for bug-fixes section. Default is "<strong>Fixed bugs:</strong></p>
+
+<p>   --enhancement-label [LABEL]</p>
+
+<p>   Setup custom label for enhancements section. Default is "<strong>Implemented enhancements:</strong>"</p>
+
+<p>   --issues-label [LABEL]</p>
+
+<p>   Setup custom label for closed-issues section. Default is "<strong>Closed issues:</strong>"</p>
+
+<p>   --header-label [LABEL]</p>
+
+<p>   Setup custom header label. Default is "# Change Log"</p>
+
+<p>   --front-matter [JSON]</p>
+
+<p>   Add YAML front matter. Formatted as JSON because it's easier to add on the command line</p>
+
+<p>   --pr-label [LABEL]</p>
+
+<p>   Setup custom label for pull requests section. Default is "<strong>Merged pull requests:</strong>"</p>
+
+<p>   --[no-]issues</p>
+
+<p>   Include closed issues in changelog. Default is true</p>
+
+<p>   --[no-]issues-wo-labels</p>
+
+<p>   Include closed issues without labels in changelog. Default is true</p>
+
+<p>   --[no-]pr-wo-labels</p>
+
+<p>   Include pull requests without labels in changelog. Default is true</p>
+
+<p>   --[no-]pull-requests</p>
+
+<p>   Include pull-requests in changelog. Default is true</p>
+
+<p>   --[no-]filter-by-milestone</p>
+
+<p>   Use milestone to detect when issue was resolved. Default is true</p>
+
+<p>   --[no-]author</p>
+
+<p>   Add author of pull-request in the end. Default is true</p>
+
+<p>   --usernames-as-github-logins</p>
+
+<p>   Use GitHub tags instead of Markdown links for the author of an issue or pull-request.</p>
+
+<p>   --unreleased-only</p>
+
+<p>   Generate log from unreleased closed issues only.</p>
+
+<p>   --[no-]unreleased</p>
+
+<p>   Add to log unreleased closed issues. Default is true</p>
+
+<p>   --unreleased-label [label]</p>
+
+<p>   Add to log unreleased closed issues. Default is true</p>
+
+<p>   --[no-]compare-link</p>
+
+<p>   Include compare link (Full Changelog) between older version and newer version. Default is true</p>
+
+<p>   --include-labels x,y,z</p>
+
+<p>   Only issues with the specified labels will be included in the changelog.</p>
+
+<p>   --exclude-labels x,y,z</p>
+
+<p>   Issues with the specified labels will be always excluded from changelog. Default is 'duplicate,question,invalid,wontfix'</p>
+
+<p>   --bug-labels x,y,z</p>
+
+<p>   Issues with the specified labels will be always added to "Fixed bugs" section. Default is 'bug,Bug'</p>
+
+<p>   --enhancement-labels x,y,z</p>
+
+<p>   Issues with the specified labels will be always added to "Implemented enhancements" section. Default is 'enhancement,Enhancement'</p>
+
+<p>   --between-tags x,y,z</p>
+
+<p>   Change log will be filled only between specified tags</p>
+
+<p>   --exclude-tags x,y,z</p>
+
+<p>   Change log will exclude specified tags</p>
+
+<p>   --exclude-tags-regex [REGEX]</p>
+
+<p>   Apply a regular expression on tag names so that they can be excluded, for example: --exclude-tags-regex ".*+\d{1,}"</p>
+
+<p>   --since-tag x</p>
+
+<p>   Change log will start after specified tag</p>
+
+<p>   --due-tag x</p>
+
+<p>   Change log will end before specified tag</p>
+
+<p>   --max-issues [NUMBER]</p>
+
+<p>   Max number of issues to fetch from GitHub. Default is unlimited</p>
+
+<p>   --release-url [URL]</p>
+
+<p>   The URL to point to for release links, in printf format (with the tag as variable).</p>
+
+<p>   --github-site [URL]</p>
+
+<p>   The Enterprise Github site on which your project is hosted.</p>
+
+<p>   --github-api [URL]</p>
+
+<p>   The enterprise endpoint to use for your Github API.</p>
+
+<p>   --simple-list</p>
+
+<p>   Create simple list from issues and pull requests. Default is false.</p>
+
+<p>   --future-release [RELEASE-VERSION]</p>
+
+<p>   Put the unreleased changes in the specified release number.</p>
+
+<p>   --release-branch [RELEASE-BRANCH]</p>
+
+<p>   Limit pull requests to the release branch, such as master or release</p>
+
+<p>   --http-cache</p>
+
+<p>   Use HTTP Cache to cache Github API requests (useful for large repos) Default is true.</p>
+
+<p>   --[no-]cache-file [CACHE-FILE]</p>
+
+<p>   Filename to use for cache. Default is /tmp/github-changelog-http-cache</p>
+
+<p>   --cache-log [CACHE-LOG]</p>
+
+<p>   Filename to use for cache log. Default is /tmp/github-changelog-logger.log</p>
+
+<p>   --[no-]verbose</p>
+
+<p>   Run verbosely. Default is true</p>
+
+<p>  -v, --version</p>
+
+<p>  Print version number</p>
+
+<p>  -h, --help</p>
+
+<p>  Displays Help</p>
+
+<h2 id="EXAMPLES">EXAMPLES</h2>
+
+<h2 id="AUTHOR">AUTHOR</h2>
+
+<p>Written by Petr Korolev sky4winder@gmail.com</p>
+
+<h2 id="REPORTING-BUGS">REPORTING BUGS</h2>
+
+<p>&lt;<a href="https://github.com/skywinder/github-changelog-generator/issues" data-bare-link="true">https://github.com/skywinder/github-changelog-generator/issues</a>&gt;</p>
+
+<h2 id="SEE-ALSO">SEE ALSO</h2>
+
+<p>&lt;<a href="https://github.com/skywinder/github-changelog-generator/" data-bare-link="true">https://github.com/skywinder/github-changelog-generator/</a>&gt;</p>
+
+
+  <ol class='man-decor man-foot man foot'>
+    <li class='tl'></li>
+    <li class='tc'>November 2016</li>
+    <li class='tr'>git-generate-changelog(1)</li>
+  </ol>
+
+  </div>
+</body>
+</html>

--- a/man/git-generate-changelog.md
+++ b/man/git-generate-changelog.md
@@ -51,6 +51,10 @@ Automatically generate change log from your tags, issues, labels and pull reques
 
    Setup custom header label. Default is "# Change Log"
 
+   --front-matter [JSON]
+
+   Add YAML front matter. Formatted as JSON because it's easier to add on the command line
+
    --pr-label [LABEL]
 
    Setup custom label for pull requests section. Default is "**Merged pull requests:**"
@@ -78,6 +82,10 @@ Automatically generate change log from your tags, issues, labels and pull reques
    --[no-]author
 
    Add author of pull-request in the end. Default is true
+
+   --usernames-as-github-logins
+
+   Use GitHub tags instead of Markdown links for the author of an issue or pull-request.
 
    --unreleased-only
 
@@ -119,6 +127,10 @@ Automatically generate change log from your tags, issues, labels and pull reques
 
    Change log will exclude specified tags
 
+   --exclude-tags-regex [REGEX]
+
+   Apply a regular expression on tag names so that they can be excluded, for example: --exclude-tags-regex ".*\+\d{1,}"
+
    --since-tag x
 
    Change log will start after specified tag
@@ -150,6 +162,22 @@ Automatically generate change log from your tags, issues, labels and pull reques
    --future-release [RELEASE-VERSION]
 
    Put the unreleased changes in the specified release number.
+
+   --release-branch [RELEASE-BRANCH]
+
+   Limit pull requests to the release branch, such as master or release
+
+   --http-cache
+
+   Use HTTP Cache to cache Github API requests (useful for large repos) Default is true.
+
+   --[no-]cache-file [CACHE-FILE]
+
+   Filename to use for cache. Default is /tmp/github-changelog-http-cache
+
+   --cache-log [CACHE-LOG]
+
+   Filename to use for cache log. Default is /tmp/github-changelog-logger.log
 
    --[no-]verbose
 


### PR DESCRIPTION
This PR amends the man page and adds regenerated content from it.

The man page is created using ronn, and gems like [manpages](https://github.com/bitboxer/manpages) can help you read the man pages on your machine.