### PR TITLE
Fixed issue #304 - entries of previous tags are included.

### DIFF
--- a/lib/github_changelog_generator/generator/generator.rb
+++ b/lib/github_changelog_generator/generator/generator.rb
@@ -11,7 +11,7 @@ module GitHubChangelogGenerator
   end
 
   class Generator
-    attr_accessor :options, :filtered_tags, :github, :tag_section_mapping
+    attr_accessor :options, :filtered_tags, :github, :tag_section_mapping, :sorted_tags
 
     # A Generator responsible for all logic, related with change log generation from ready-to-parse issues
     #

--- a/lib/github_changelog_generator/generator/generator_generation.rb
+++ b/lib/github_changelog_generator/generator/generator_generation.rb
@@ -126,8 +126,9 @@ module GitHubChangelogGenerator
     def generate_unreleased_section
       log = ""
       if options[:unreleased]
-        unreleased_log = generate_log_between_tags(filtered_tags[0], nil)
-        log += unreleased_log if unreleased_log
+        start_tag      = filtered_tags[0] || sorted_tags.last
+        unreleased_log = generate_log_between_tags(start_tag, nil)
+        log           += unreleased_log if unreleased_log
       end
       log
     end

--- a/lib/github_changelog_generator/generator/generator_processor.rb
+++ b/lib/github_changelog_generator/generator/generator_processor.rb
@@ -97,6 +97,8 @@ module GitHubChangelogGenerator
     def ensure_older_tag(older_tag, newer_tag)
       return older_tag if older_tag
       idx = sorted_tags.index { |t| t["name"] == newer_tag["name"] }
+      # skip if we are already at the oldest element
+      return if idx == sorted_tags.size - 1
       sorted_tags[idx - 1]
     end
 

--- a/lib/github_changelog_generator/generator/generator_processor.rb
+++ b/lib/github_changelog_generator/generator/generator_processor.rb
@@ -72,6 +72,8 @@ module GitHubChangelogGenerator
       # in case if not tags specified - return unchanged array
       return issues if older_tag.nil? && newer_tag.nil?
 
+      older_tag = ensure_older_tag(older_tag, newer_tag)
+
       newer_tag_time = newer_tag && get_time_of_tag(newer_tag)
       older_tag_time = older_tag && get_time_of_tag(older_tag)
 
@@ -90,6 +92,12 @@ module GitHubChangelogGenerator
           false
         end
       end
+    end
+
+    def ensure_older_tag(older_tag, newer_tag)
+      return older_tag if older_tag
+      idx = sorted_tags.index { |t| t["name"] == newer_tag["name"] }
+      sorted_tags[idx - 1]
     end
 
     def tag_older_new_tag?(newer_tag_time, time)

--- a/lib/github_changelog_generator/generator/generator_tags.rb
+++ b/lib/github_changelog_generator/generator/generator_tags.rb
@@ -10,8 +10,8 @@ module GitHubChangelogGenerator
       included_tags = filter_excluded_tags(all_tags)
 
       fetch_tags_dates(all_tags) # Creates a Hash @tag_times_hash
-      sorted_tags          = sort_tags_by_date(included_tags)
-      @filtered_tags       = get_filtered_tags(included_tags)
+      @sorted_tags   = sort_tags_by_date(included_tags)
+      @filtered_tags = get_filtered_tags(included_tags)
 
       @tag_section_mapping = build_tag_section_mapping(@filtered_tags, sorted_tags)
 


### PR DESCRIPTION
This pull requests fixes the issue #304 .

ATTENTION: This pull request changes the current behavior!

Current behavior:
Use since_tag or due_tag and every issue, PR etc. that happened before the last tag will get added to the last tag.

New behavior:
Use since_tag or due_tag and every issue, PR etc. that happened in the timeframe of the tags is added to the tags. Previous elements are not added to the list.

Feedback is welcome. Cheers!
