### PR TITLE
Option --unreleased-label explained

### DIFF
--- a/lib/github_changelog_generator/parser.rb
+++ b/lib/github_changelog_generator/parser.rb
@@ -107,7 +107,7 @@ module GitHubChangelogGenerator
         opts.on("--[no-]unreleased", "Add to log unreleased closed issues. Default is true") do |v|
           options[:unreleased] = v
         end
-        opts.on("--unreleased-label [label]", "Add to log unreleased closed issues. Default is true") do |v|
+        opts.on("--unreleased-label [label]", "Setup custom label for unreleased closed issues section. Default is \"**Unreleased:**\"") do |v|
           options[:unreleased_label] = v
         end
         opts.on("--[no-]compare-link", "Include compare link (Full Changelog) between older version and newer version. Default is true") do |v|

--- a/man/git-generate-changelog.1
+++ b/man/git-generate-changelog.1
@@ -142,7 +142,7 @@ Add to log unreleased closed issues\. Default is true
 \-\-unreleased\-label [label]
 .
 .P
-Add to log unreleased closed issues\. Default is true
+Setup custom label for unreleased closed issues section\. Default is "\fBUnreleased:\fR"
 .
 .P
 \-\-[no\-]compare\-link

--- a/man/git-generate-changelog.1.html
+++ b/man/git-generate-changelog.1.html
@@ -170,7 +170,7 @@
 
 <p>   --unreleased-label [label]</p>
 
-<p>   Add to log unreleased closed issues. Default is true</p>
+<p>   Setup custom label for unreleased closed issues section. Default is "<strong>Unreleased:</strong>"</p>
 
 <p>   --[no-]compare-link</p>
 

--- a/man/git-generate-changelog.md
+++ b/man/git-generate-changelog.md
@@ -97,7 +97,7 @@ Automatically generate change log from your tags, issues, labels and pull reques
 
    --unreleased-label [label]
 
-   Add to log unreleased closed issues. Default is true
+   Setup custom label for unreleased closed issues section. Default is "**Unreleased:**"
 
    --[no-]compare-link
 


### PR DESCRIPTION
This PR corrects the options help text for `--unreleased-label`.

See #374