### PR TITLE
Travis: Use ruby 2.3.3 and 2.2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,16 +6,16 @@ before_install:
   - gem install bundler
 matrix:
   include:
-    - rvm: 2.2.2
+    - rvm: 2.2.6
       install: true # This skips 'bundle install'
       script: gem build github_changelog_generator && gem install *.gem
-    - rvm: 2.2.2
+    - rvm: 2.2.6
       install: true # This skips 'bundle install'
       script: gem build github_changelog_generator && bundle install
       gemfile: spec/install-gem-in-bundler.gemfile
     - rvm: 2.1
       gemfile: gemfiles/Gemfile.2_1
-    - rvm: 2.3.1
+    - rvm: 2.3.2
       gemfile: gemfiles/Gemfile.2_3_1
     - rvm: 2.4.0-preview3
       gemfile: gemfiles/Gemfile.2_4_0

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
       gemfile: spec/install-gem-in-bundler.gemfile
     - rvm: 2.1
       gemfile: gemfiles/Gemfile.2_1
-    - rvm: 2.3.2
+    - rvm: 2.3.3
       gemfile: gemfiles/Gemfile.2_3_1
     - rvm: 2.4.0-preview3
       gemfile: gemfiles/Gemfile.2_4_0


### PR DESCRIPTION
This PR updates the MRI rubies in the Travis build to the latest versions.

Update: Will have to wait until the `rvm` has them.