### PR TITLE
Order Gemfile gems A-Z; add ruby version marker

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 source "https://rubygems.org"
 
+ruby RUBY_VERSION
+
 gemspec
 
 group :development, :test do
-  gem "rake"
   gem "bundler"
   gem "overcommit", ">= 0.31"
+  gem "rake"
   gem "rubocop", ">= 0.43"
 end
 
@@ -15,16 +17,12 @@ group :development do
 end
 
 group :test do
-  gem "vcr"
-  gem "multi_json"
-  gem "webmock"
-  gem "coveralls", "~>0.8", require: false
-  gem "simplecov", "~>0.10", require: false
   gem "codeclimate-test-reporter", "~>0.4"
-  if RUBY_VERSION > "2"
-    gem "json", "~> 2.0", ">= 2.0.2"
-  else
-    gem "json"
-  end
+  gem "coveralls", "~>0.8", require: false
+  gem "json"
+  gem "multi_json"
   gem "rspec", "< 4"
+  gem "simplecov", "~>0.10", require: false
+  gem "vcr"
+  gem "webmock"
 end


### PR DESCRIPTION
While fixing another defect, I noted that the Rubocop rules had expanded once more: ordering of gems in Gemfile.

- Gemfile: Order all gems a-z
- Gemfile: Remove the `if` on RUBY_VERSION and add the `ruby` version marker trick

This build failed due to this: https://travis-ci.org/skywinder/github-changelog-generator/jobs/180823342