### PR TITLE
Gemfiles for building versions separately dropped

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,14 +14,10 @@ matrix:
       script: gem build github_changelog_generator && bundle install
       gemfile: spec/install-gem-in-bundler.gemfile
     - rvm: 2.1
-      gemfile: gemfiles/Gemfile.2_1
     - rvm: 2.3.3
-      gemfile: gemfiles/Gemfile.2_3_1
     - rvm: 2.4.0-preview3
-      gemfile: gemfiles/Gemfile.2_4_0
     - rvm: jruby-9.1.6.0
       jdk: oraclejdk8
-      gemfile: gemfiles/Gemfile.jruby-9.1
       env:
         - JRUBY_OPTS=--debug
 

--- a/gemfiles/Gemfile.2_1
+++ b/gemfiles/Gemfile.2_1
@@ -1,3 +1,0 @@
-eval_gemfile File.expand_path('../../Gemfile', __FILE__)
-gem 'rack', '~> 1.6'
-gem 'activesupport', '~> 4'

--- a/gemfiles/Gemfile.2_3_1
+++ b/gemfiles/Gemfile.2_3_1
@@ -1,3 +1,0 @@
-eval_gemfile File.expand_path('../../Gemfile', __FILE__)
-gem 'rack', '>= 2'
-gem 'activesupport', '>= 4'

--- a/gemfiles/Gemfile.2_4_0
+++ b/gemfiles/Gemfile.2_4_0
@@ -1,3 +1,0 @@
-eval_gemfile File.expand_path('../../Gemfile', __FILE__)
-gem 'rack', '>= 2'
-

--- a/gemfiles/Gemfile.jruby-9.1
+++ b/gemfiles/Gemfile.jruby-9.1
@@ -1,3 +1,0 @@
-eval_gemfile File.expand_path('../../Gemfile', __FILE__)
-gem 'rack', '>= 2'
-


### PR DESCRIPTION
This PR simplifies the Travis configuration a lot: it drops the Gemfile annotations and their files.

 - simpler build by using the ruby version marker in shared gemfile
 - Bundler can take care of itself