### PR TITLE
Gemspec: demand rainbow 2.2.1+

### DIFF
--- a/github_changelog_generator.gemspec
+++ b/github_changelog_generator.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "rake", ">= 10.0"
-  spec.add_runtime_dependency "rainbow", ">= 2.1"
+  spec.add_runtime_dependency "rainbow", ">= 2.2.1"
   spec.add_runtime_dependency("octokit", ["~> 4.6"])
   spec.add_runtime_dependency("faraday-http-cache")
   spec.add_runtime_dependency("activesupport")


### PR DESCRIPTION
This PR makes the gemspec ask for a rainbow gem version which does not cause a warning on Ruby 2.4.0.