### PR TITLE
Gemspec: update retriable to 3.0

### DIFF
--- a/github_changelog_generator.gemspec
+++ b/github_changelog_generator.gemspec
@@ -29,6 +29,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency("octokit", ["~> 4.6"])
   spec.add_runtime_dependency("faraday-http-cache")
   spec.add_runtime_dependency("activesupport")
-  spec.add_runtime_dependency("retriable", ["~> 2.1"])
+  spec.add_runtime_dependency("retriable", ["~> 3.0"])
   spec.add_runtime_dependency("multi_json")
 end


### PR DESCRIPTION
This PR updates the dependency retriable to its 3.0.

[CHANGELOG](https://github.com/kamui/retriable/blob/master/CHANGELOG.md)