### PR TITLE
Update to latest CodeClimate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,3 +32,5 @@ addons:
   code_climate:
     repo_token:
       secure: iMpV5IAvH+/EVGZrpWnt2BnmNFzSbsRcIumsr4ZyLC8N5nrCSXyjCSy0g48btL3Sj0bSgK9hcrJsmrFd2bkqFleyAcPAzNyUQzBuIRZx47O8yFmbZ+Pj+l3+KOlmcbzJNHfDfxkxuWTmTAcSDfsiyApin721T/ey3SUuwKpZNUc=
+after_success:
+  - bundle exec codeclimate-test-reporter

--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ group :development do
 end
 
 group :test do
-  gem "codeclimate-test-reporter", "~>0.4"
+  gem "codeclimate-test-reporter", "~> 1.0"
   gem "coveralls", "~>0.8", require: false
   gem "json"
   gem "multi_json"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,7 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-require "codeclimate-test-reporter"
 require "simplecov"
 require "coveralls"
 require "vcr"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,8 +27,7 @@ end
 
 SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
                                                                  Coveralls::SimpleCov::Formatter,
-                                                                 SimpleCov::Formatter::HTMLFormatter,
-                                                                 CodeClimate::TestReporter::Formatter
+                                                                 SimpleCov::Formatter::HTMLFormatter
                                                                ])
 SimpleCov.start do
   add_filter "gemfiles/"


### PR DESCRIPTION
This PR updates CodeClimate code coverage reporter to their latest offering.

It changes the configuration, to call their tool `after_success` in Travis, and so forth.