### PR TITLE
Travis: jruby-9.1.8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
     - rvm: 2.1
     - rvm: 2.3.3
     - rvm: 2.4.0
-    - rvm: jruby-9.1.7.0
+    - rvm: jruby-9.1.8.0
       jdk: oraclejdk8
       env:
         - JRUBY_OPTS=--debug


### PR DESCRIPTION
This PR updates JRuby in Travis to latest stable.