### PR TITLE
Rescue invalid commands and present the valid options list

### DIFF
--- a/lib/github_changelog_generator/parser.rb
+++ b/lib/github_changelog_generator/parser.rb
@@ -13,7 +13,12 @@ module GitHubChangelogGenerator
       ParserFile.new(options).parse!
 
       parser = setup_parser(options)
-      parser.parse!
+      begin parser.parse!
+      rescue OptionParser::InvalidOption => e
+        puts e
+        puts parser
+        exit 1
+      end
 
       fetch_user_and_project(options)
 

--- a/lib/github_changelog_generator/parser.rb
+++ b/lib/github_changelog_generator/parser.rb
@@ -15,9 +15,7 @@ module GitHubChangelogGenerator
       parser = setup_parser(options)
       begin parser.parse!
       rescue OptionParser::InvalidOption => e
-        puts e
-        puts parser
-        exit 1
+        abort [e, parser].join("\n")
       end
 
       fetch_user_and_project(options)


### PR DESCRIPTION
So, it won't print out freaking out an exception when you do `github-changelog-generator --version`. 😃 