### PR TITLE
Fix RubyCops warnings for Travis CI

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,7 @@ AllCops:
   Exclude:
     - 'vendor/**/*'
     - 'gemfiles/**/*'
+    - 'spec/**/*'
 
 Metrics/LineLength:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 source "https://rubygems.org"
 
 ruby RUBY_VERSION

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require "bundler"
 require "bundler/gem_tasks"
 require "rubocop/rake_task"
@@ -11,7 +12,7 @@ RuboCop::RakeTask.new
 RSpec::Core::RakeTask.new(:rspec)
 
 task :copy_man_page_to_manpath do |_t|
-  known_manpath_paths = %w(/etc/manpath.config /etc/manpaths)
+  known_manpath_paths = %w[/etc/manpath.config /etc/manpaths]
   manpath = known_manpath_paths.find do |f|
     path = Pathname(f)
     path.file? && path.readable?
@@ -36,5 +37,5 @@ task :copy_man_page_to_manpath do |_t|
   end
 end
 
-task checks: [:rubocop, :rspec]
-task default: [:rubocop, :rspec]
+task checks: %i[rubocop rspec]
+task default: %i[rubocop rspec]

--- a/github_changelog_generator.gemspec
+++ b/github_changelog_generator.gemspec
@@ -1,5 +1,6 @@
 # coding: utf-8
 # frozen_string_literal: true
+
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "github_changelog_generator/version"
@@ -18,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.homepage = "https://github.com/skywinder/Github-Changelog-Generator"
   spec.license = "MIT"
 
-  spec.files = Dir["{bin,lib,man,spec}/**/*"] + %w(LICENSE Rakefile README.md)
+  spec.files = Dir["{bin,lib,man,spec}/**/*"] + %w[LICENSE Rakefile README.md]
 
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})

--- a/lib/github_changelog_generator/generator/generator.rb
+++ b/lib/github_changelog_generator/generator/generator.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative "../octo_fetcher"
 require_relative "generator_generation"
 require_relative "generator_fetcher"
@@ -42,7 +43,7 @@ module GitHubChangelogGenerator
     def encapsulate_string(string)
       string.gsub! '\\', '\\\\'
 
-      encpas_chars = %w(< > * _ \( \) [ ] #)
+      encpas_chars = %w[< > * _ \( \) [ ] #]
       encpas_chars.each do |char|
         string.gsub! char, "\\#{char}"
       end

--- a/lib/github_changelog_generator/generator/generator_fetcher.rb
+++ b/lib/github_changelog_generator/generator/generator_fetcher.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module GitHubChangelogGenerator
   class Generator
     MAX_THREAD_NUMBER = 25

--- a/lib/github_changelog_generator/generator/generator_generation.rb
+++ b/lib/github_changelog_generator/generator/generator_generation.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module GitHubChangelogGenerator
   class Generator
     # Main function to start change log generation

--- a/lib/github_changelog_generator/generator/generator_processor.rb
+++ b/lib/github_changelog_generator/generator/generator_processor.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module GitHubChangelogGenerator
   class Generator
     # delete all labels with labels from options[:exclude_labels] array
@@ -132,8 +133,8 @@ module GitHubChangelogGenerator
     # @return [Array] issues without labels or empty array if add_issues_wo_labels is false
     def filter_wo_labels(issues)
       if options[:add_issues_wo_labels]
-        issues_wo_labels = issues.select do |issue|
-          !issue["labels"].map { |l| l["name"] }.any?
+        issues_wo_labels = issues.find_all do |issue|
+          !issue["labels"].map { |l| l["name"] }.one?
         end
         return issues_wo_labels
       end
@@ -197,7 +198,7 @@ module GitHubChangelogGenerator
         end
       end
 
-      pull_requests.select! do |pr|
+      pull_requests.find_all! do |pr|
         !pr["merged_at"].nil?
       end
 

--- a/lib/github_changelog_generator/generator/generator_tags.rb
+++ b/lib/github_changelog_generator/generator/generator_tags.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module GitHubChangelogGenerator
   class Generator
     # fetch, filter tags, fetch dates and sort them in time order

--- a/lib/github_changelog_generator/helper.rb
+++ b/lib/github_changelog_generator/helper.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require "logger"
 require "rainbow"
 

--- a/lib/github_changelog_generator/octo_fetcher.rb
+++ b/lib/github_changelog_generator/octo_fetcher.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require "tmpdir"
 require "retriable"
 module GitHubChangelogGenerator

--- a/lib/github_changelog_generator/options.rb
+++ b/lib/github_changelog_generator/options.rb
@@ -1,55 +1,56 @@
 # frozen_string_literal: true
+
 require "delegate"
 module GitHubChangelogGenerator
   class Options < SimpleDelegator
     UnsupportedOptionError = Class.new(ArgumentError)
 
-    KNOWN_OPTIONS = [
-      :add_issues_wo_labels,
-      :add_pr_wo_labels,
-      :author,
-      :base,
-      :between_tags,
-      :bug_labels,
-      :bug_prefix,
-      :cache_file,
-      :cache_log,
-      :compare_link,
-      :date_format,
-      :due_tag,
-      :enhancement_labels,
-      :enhancement_prefix,
-      :exclude_labels,
-      :exclude_tags,
-      :exclude_tags_regex,
-      :filter_issues_by_milestone,
-      :frontmatter,
-      :future_release,
-      :git_remote,
-      :github_endpoint,
-      :github_site,
-      :header,
-      :http_cache,
-      :include_labels,
-      :issue_prefix,
-      :issue_line_labels,
-      :issues,
-      :max_issues,
-      :merge_prefix,
-      :output,
-      :project,
-      :pulls,
-      :release_branch,
-      :release_url,
-      :simple_list,
-      :since_tag,
-      :token,
-      :unreleased,
-      :unreleased_label,
-      :unreleased_only,
-      :user,
-      :usernames_as_github_logins,
-      :verbose
+    KNOWN_OPTIONS = %i[
+      add_issues_wo_labels
+      add_pr_wo_labels
+      author
+      base
+      between_tags
+      bug_labels
+      bug_prefix
+      cache_file
+      cache_log
+      compare_link
+      date_format
+      due_tag
+      enhancement_labels
+      enhancement_prefix
+      exclude_labels
+      exclude_tags
+      exclude_tags_regex
+      filter_issues_by_milestone
+      frontmatter
+      future_release
+      git_remote
+      github_endpoint
+      github_site
+      header
+      http_cache
+      include_labels
+      issue_prefix
+      issue_line_labels
+      issues
+      max_issues
+      merge_prefix
+      output
+      project
+      pulls
+      release_branch
+      release_url
+      simple_list
+      since_tag
+      token
+      unreleased
+      unreleased_label
+      unreleased_only
+      user
+      usernames_as_github_logins
+      verbose
     ]
 
     def initialize(values)

--- a/lib/github_changelog_generator/parser.rb
+++ b/lib/github_changelog_generator/parser.rb
@@ -13,7 +13,12 @@ module GitHubChangelogGenerator
       ParserFile.new(options).parse!
 
       parser = setup_parser(options)
-      parser.parse!
+      begin parser.parse!
+      rescue OptionParser::InvalidOption => e
+        puts e
+        puts parser
+        exit 1
+      end
 
       fetch_user_and_project(options)
 

--- a/lib/github_changelog_generator/parser.rb
+++ b/lib/github_changelog_generator/parser.rb
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
+
 require "optparse"
 require "pp"
 require_relative "version"
@@ -206,9 +207,9 @@ module GitHubChangelogGenerator
         unreleased: true,
         unreleased_label: "Unreleased",
         compare_link: true,
-        enhancement_labels: %w(enhancement Enhancement),
-        bug_labels: %w(bug Bug),
-        exclude_labels: %w(duplicate question invalid wontfix Duplicate Question Invalid Wontfix),
+        enhancement_labels: %w[enhancement Enhancement],
+        bug_labels: %w[bug Bug],
+        exclude_labels: %w[duplicate question invalid wontfix Duplicate Question Invalid Wontfix],
         issue_line_labels: [],
         max_issues: nil,
         simple_list: false,

--- a/lib/github_changelog_generator/parser.rb
+++ b/lib/github_changelog_generator/parser.rb
@@ -15,9 +15,7 @@ module GitHubChangelogGenerator
       parser = setup_parser(options)
       begin parser.parse!
       rescue OptionParser::InvalidOption => e
-        puts e
-        puts parser
-        exit 1
+        abort [e, parser].join("\n")
       end
 
       fetch_user_and_project(options)

--- a/lib/github_changelog_generator/parser_file.rb
+++ b/lib/github_changelog_generator/parser_file.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require "pathname"
 
 module GitHubChangelogGenerator
@@ -65,9 +66,8 @@ module GitHubChangelogGenerator
       [key.tr("-", "_").to_sym, value.gsub(/[\n\r]+/, "")]
     end
 
-    KNOWN_ARRAY_KEYS = [:exclude_labels, :include_labels, :bug_labels,
-                        :enhancement_labels, :issue_line_labels, :between_tags, :exclude_tags]
-    KNOWN_INTEGER_KEYS = [:max_issues]
+    KNOWN_ARRAY_KEYS = %i[exclude_labels include_labels bug_labels enhancement_labels issue_line_labels between_tags exclude_tags]
+    KNOWN_INTEGER_KEYS = %i[max_issues]
 
     def convert_value(value, option_name)
       if KNOWN_ARRAY_KEYS.include?(option_name)

--- a/lib/github_changelog_generator/reader.rb
+++ b/lib/github_changelog_generator/reader.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-#
+
 # Author:: Enrico Stahn <mail@enricostahn.com>
 #
 # Copyright 2014, Zanui, <engineering@zanui.com.au>

--- a/lib/github_changelog_generator/task.rb
+++ b/lib/github_changelog_generator/task.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require "rake"
 require "rake/tasklib"
 require "github_changelog_generator"
@@ -7,7 +8,7 @@ module GitHubChangelogGenerator
   class RakeTask < ::Rake::TaskLib
     include ::Rake::DSL if defined?(::Rake::DSL)
 
-    OPTIONS = %w( user project token date_format output
+    OPTIONS = %w[ user project token date_format output
                   bug_prefix enhancement_prefix issue_prefix
                   header merge_prefix issues
                   add_issues_wo_labels add_pr_wo_labels
@@ -18,7 +19,7 @@ module GitHubChangelogGenerator
                   between_tags exclude_tags exclude_tags_regex since_tag max_issues
                   github_site github_endpoint simple_list
                   future_release release_branch verbose release_url
-                  base )
+                  base ]
 
     OPTIONS.each do |o|
       attr_accessor o.to_sym

--- a/lib/github_changelog_generator/version.rb
+++ b/lib/github_changelog_generator/version.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module GitHubChangelogGenerator
   VERSION = "1.14.3"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-#
+
 # Author:: Enrico Stahn <mail@enricostahn.com>
 #
 # Copyright 2014, Zanui, <engineering@zanui.com.au>

--- a/spec/unit/generator/generator_processor_spec.rb
+++ b/spec/unit/generator/generator_processor_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module GitHubChangelogGenerator
   describe Generator do
     context "#exclude_issues_by_labels" do
@@ -7,7 +8,7 @@ module GitHubChangelogGenerator
       let(:good_label) { { "name" => "GOOD" } }
       let(:good_issue) { { "labels" => [good_label] } }
       let(:issues) { [issue, good_issue] }
-      subject(:generator) { described_class.new(exclude_labels: %w(BAD BOO)) }
+      subject(:generator) { described_class.new(exclude_labels: %w[BAD BOO]) }
 
       it "removes issues with labels in the exclude_label list" do
         result = generator.exclude_issues_by_labels(issues)

--- a/spec/unit/generator/generator_tags_spec.rb
+++ b/spec/unit/generator/generator_tags_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 describe GitHubChangelogGenerator::Generator do
   def tag_with_name(tag)
     {
@@ -19,167 +20,167 @@ describe GitHubChangelogGenerator::Generator do
       end
 
       subject do
-        @generator.get_filtered_tags(tags_from_strings(%w(1 2 3)))
+        @generator.get_filtered_tags(tags_from_strings(%w[1 2 3]))
       end
       it { is_expected.to be_a(Array) }
-      it { is_expected.to match_array(tags_from_strings(%w(1 2 3))) }
+      it { is_expected.to match_array(tags_from_strings(%w[1 2 3])) }
     end
     context "when between_tags same as input array" do
       before do
-        @generator = GitHubChangelogGenerator::Generator.new(between_tags: %w(1 2 3))
+        @generator = GitHubChangelogGenerator::Generator.new(between_tags: %w[1 2 3])
       end
       subject do
-        @generator.get_filtered_tags(tags_from_strings(%w(1 2 3)))
+        @generator.get_filtered_tags(tags_from_strings(%w[1 2 3]))
       end
       it { is_expected.to be_a(Array) }
-      it { is_expected.to match_array(tags_from_strings(%w(1 2 3))) }
+      it { is_expected.to match_array(tags_from_strings(%w[1 2 3])) }
     end
 
     context "when between_tags filled with correct values" do
       before do
-        @generator = GitHubChangelogGenerator::Generator.new(between_tags: %w(1 2))
+        @generator = GitHubChangelogGenerator::Generator.new(between_tags: %w[1 2])
       end
       subject do
-        @generator.get_filtered_tags(tags_from_strings(%w(1 2 3)))
+        @generator.get_filtered_tags(tags_from_strings(%w[1 2 3]))
       end
       it { is_expected.to be_a(Array) }
-      it { is_expected.to match_array(tags_from_strings(%w(1 2))) }
+      it { is_expected.to match_array(tags_from_strings(%w[1 2])) }
     end
 
     context "when between_tags filled with invalid values" do
       before do
-        @generator = GitHubChangelogGenerator::Generator.new(between_tags: %w(1 q w))
+        @generator = GitHubChangelogGenerator::Generator.new(between_tags: %w[1 q w])
       end
 
       subject do
-        @generator.get_filtered_tags(tags_from_strings(%w(1 2 3)))
+        @generator.get_filtered_tags(tags_from_strings(%w[1 2 3]))
       end
       it { is_expected.to be_a(Array) }
-      it { is_expected.to match_array(tags_from_strings(%w(1))) }
+      it { is_expected.to match_array(tags_from_strings(%w[1])) }
     end
   end
 
   describe "#get_filtered_tags" do
     subject do
-      generator.get_filtered_tags(tags_from_strings(%w(1 2 3 4 5)))
+      generator.get_filtered_tags(tags_from_strings(%w[1 2 3 4 5]))
     end
 
     context "respects between tags" do
-      let(:generator) { GitHubChangelogGenerator::Generator.new(between_tags: %w(1 2 3)) }
+      let(:generator) { GitHubChangelogGenerator::Generator.new(between_tags: %w[1 2 3]) }
 
       it { is_expected.to be_a Array }
-      it { is_expected.to match_array(tags_from_strings(%w(1 2 3))) }
+      it { is_expected.to match_array(tags_from_strings(%w[1 2 3])) }
     end
   end
 
   describe "#filter_excluded_tags" do
-    subject { generator.filter_excluded_tags(tags_from_strings(%w(1 2 3))) }
+    subject { generator.filter_excluded_tags(tags_from_strings(%w[1 2 3])) }
 
     context "with matching string" do
-      let(:generator) { GitHubChangelogGenerator::Generator.new(exclude_tags: %w(3)) }
+      let(:generator) { GitHubChangelogGenerator::Generator.new(exclude_tags: %w[3]) }
       it { is_expected.to be_a Array }
-      it { is_expected.to match_array(tags_from_strings(%w(1 2))) }
+      it { is_expected.to match_array(tags_from_strings(%w[1 2])) }
     end
 
     context "with non-matching string" do
-      let(:generator) { GitHubChangelogGenerator::Generator.new(exclude_tags: %w(invalid tags)) }
+      let(:generator) { GitHubChangelogGenerator::Generator.new(exclude_tags: %w[invalid tags]) }
       it { is_expected.to be_a Array }
-      it { is_expected.to match_array(tags_from_strings(%w(1 2 3))) }
+      it { is_expected.to match_array(tags_from_strings(%w[1 2 3])) }
     end
 
     context "with matching regex" do
       let(:generator) { GitHubChangelogGenerator::Generator.new(exclude_tags: /[23]/) }
       it { is_expected.to be_a Array }
-      it { is_expected.to match_array(tags_from_strings(%w(1))) }
+      it { is_expected.to match_array(tags_from_strings(%w[1])) }
     end
 
     context "with non-matching regex" do
       let(:generator) { GitHubChangelogGenerator::Generator.new(exclude_tags: /[abc]/) }
       it { is_expected.to be_a Array }
-      it { is_expected.to match_array(tags_from_strings(%w(1 2 3))) }
+      it { is_expected.to match_array(tags_from_strings(%w[1 2 3])) }
     end
   end
 
   describe "#filter_excluded_tags_regex" do
-    subject { generator.filter_excluded_tags(tags_from_strings(%w(1 2 3))) }
+    subject { generator.filter_excluded_tags(tags_from_strings(%w[1 2 3])) }
 
     context "with matching regex" do
       let(:generator) { GitHubChangelogGenerator::Generator.new(exclude_tags_regex: "[23]") }
       it { is_expected.to be_a Array }
-      it { is_expected.to match_array(tags_from_strings(%w(1))) }
+      it { is_expected.to match_array(tags_from_strings(%w[1])) }
     end
 
     context "with non-matching regex" do
       let(:generator) { GitHubChangelogGenerator::Generator.new(exclude_tags_regex: "[45]") }
       it { is_expected.to be_a Array }
-      it { is_expected.to match_array(tags_from_strings(%w(1 2 3))) }
+      it { is_expected.to match_array(tags_from_strings(%w[1 2 3])) }
     end
   end
 
   describe "#filter_since_tag" do
     context "with filled array" do
-      subject { generator.filter_since_tag(tags_from_strings(%w(1 2 3))) }
+      subject { generator.filter_since_tag(tags_from_strings(%w[1 2 3])) }
 
       context "with valid since tag" do
         let(:generator) { GitHubChangelogGenerator::Generator.new(since_tag: "2") }
         it { is_expected.to be_a Array }
-        it { is_expected.to match_array(tags_from_strings(%w(1))) }
+        it { is_expected.to match_array(tags_from_strings(%w[1])) }
       end
 
       context "with invalid since tag" do
         let(:generator) { GitHubChangelogGenerator::Generator.new(since_tag: "Invalid tag") }
         it { is_expected.to be_a Array }
-        it { is_expected.to match_array(tags_from_strings(%w(1 2 3))) }
+        it { is_expected.to match_array(tags_from_strings(%w[1 2 3])) }
       end
     end
 
     context "with empty array" do
-      subject { generator.filter_since_tag(tags_from_strings(%w())) }
+      subject { generator.filter_since_tag(tags_from_strings(%w[])) }
 
       context "with valid since tag" do
         let(:generator) { GitHubChangelogGenerator::Generator.new(since_tag: "2") }
         it { is_expected.to be_a Array }
-        it { is_expected.to match_array(tags_from_strings(%w())) }
+        it { is_expected.to match_array(tags_from_strings(%w[])) }
       end
 
       context "with invalid since tag" do
         let(:generator) { GitHubChangelogGenerator::Generator.new(since_tag: "Invalid tag") }
         it { is_expected.to be_a Array }
-        it { is_expected.to match_array(tags_from_strings(%w())) }
+        it { is_expected.to match_array(tags_from_strings(%w[])) }
       end
     end
   end
 
   describe "#filter_due_tag" do
     context "with filled array" do
-      subject { generator.filter_due_tag(tags_from_strings(%w(1 2 3))) }
+      subject { generator.filter_due_tag(tags_from_strings(%w[1 2 3])) }
 
       context "with valid due tag" do
         let(:generator) { GitHubChangelogGenerator::Generator.new(due_tag: "2") }
         it { is_expected.to be_a Array }
-        it { is_expected.to match_array(tags_from_strings(%w(3))) }
+        it { is_expected.to match_array(tags_from_strings(%w[3])) }
       end
 
       context "with invalid due tag" do
         let(:generator) { GitHubChangelogGenerator::Generator.new(due_tag: "Invalid tag") }
         it { is_expected.to be_a Array }
-        it { is_expected.to match_array(tags_from_strings(%w(1 2 3))) }
+        it { is_expected.to match_array(tags_from_strings(%w[1 2 3])) }
       end
     end
 
     context "with empty array" do
-      subject { generator.filter_due_tag(tags_from_strings(%w())) }
+      subject { generator.filter_due_tag(tags_from_strings(%w[])) }
 
       context "with valid due tag" do
         let(:generator) { GitHubChangelogGenerator::Generator.new(due_tag: "2") }
         it { is_expected.to be_a Array }
-        it { is_expected.to match_array(tags_from_strings(%w())) }
+        it { is_expected.to match_array(tags_from_strings(%w[])) }
       end
 
       context "with invalid due tag" do
         let(:generator) { GitHubChangelogGenerator::Generator.new(due_tag: "Invalid tag") }
         it { is_expected.to be_a Array }
-        it { is_expected.to match_array(tags_from_strings(%w())) }
+        it { is_expected.to match_array(tags_from_strings(%w[])) }
       end
     end
   end
@@ -232,13 +233,13 @@ describe GitHubChangelogGenerator::Generator do
       @generator.sort_tags_by_date(tags)
     end
     context "sort unsorted tags" do
-      let(:tags) { tags_from_strings %w(valid_tag1 valid_tag2 valid_tag3) }
+      let(:tags) { tags_from_strings %w[valid_tag1 valid_tag2 valid_tag3] }
 
       it { is_expected.to be_a_kind_of(Array) }
       it { is_expected.to match_array(tags.reverse!) }
     end
     context "sort sorted tags" do
-      let(:tags) { tags_from_strings %w(valid_tag3 valid_tag2 valid_tag1) }
+      let(:tags) { tags_from_strings %w[valid_tag3 valid_tag2 valid_tag1] }
 
       it { is_expected.to be_a_kind_of(Array) }
       it { is_expected.to match_array(tags) }

--- a/spec/unit/octo_fetcher_spec.rb
+++ b/spec/unit/octo_fetcher_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 VALID_TOKEN = "0123456789abcdef"
 INVALID_TOKEN = "0000000000000000"
 
@@ -299,7 +300,7 @@ describe GitHubChangelogGenerator::OctoFetcher do
         pull_requests = fetcher.fetch_closed_pull_requests
 
         pr = pull_requests.first
-        expect(pr.keys).to eq(%w(url id html_url diff_url patch_url issue_url number state locked title user body created_at updated_at closed_at merged_at merge_commit_sha assignee assignees milestone commits_url review_comments_url review_comment_url comments_url statuses_url head base _links))
+        expect(pr.keys).to eq(%w[url id html_url diff_url patch_url issue_url number state locked title user body created_at updated_at closed_at merged_at merge_commit_sha assignee assignees milestone commits_url review_comments_url review_comment_url comments_url statuses_url head base _links])
       end
     end
   end
@@ -500,7 +501,7 @@ describe GitHubChangelogGenerator::OctoFetcher do
         commit = fetcher.fetch_commit(event)
 
         expectations = [
-          %w(sha decfe840d1a1b86e0c28700de5362d3365a29555),
+          %w[sha decfe840d1a1b86e0c28700de5362d3365a29555],
           ["url",
            "https://api.github.com/repos/skywinder/changelog_test/commits/decfe840d1a1b86e0c28700de5362d3365a29555"],
           # OLD API: "https://api.github.com/repos/skywinder/changelog_test/git/commits/decfe840d1a1b86e0c28700de5362d3365a29555"],

--- a/spec/unit/options_spec.rb
+++ b/spec/unit/options_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 RSpec.describe GitHubChangelogGenerator::Options do
   describe "#initialize" do
     context "with known options" do

--- a/spec/unit/parse_file_spec.rb
+++ b/spec/unit/parse_file_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 describe GitHubChangelogGenerator::ParserFile do
   describe ".github_changelog_generator" do
     let(:options) { {} }

--- a/spec/unit/parser_spec.rb
+++ b/spec/unit/parser_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 describe GitHubChangelogGenerator::Parser do
   describe ".user_project_from_remote" do
     context "when remote is type 1" do

--- a/spec/unit/reader_spec.rb
+++ b/spec/unit/reader_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-#
+
 # Author:: Enrico Stahn <mail@enricostahn.com>
 #
 # Copyright 2014, Zanui, <engineering@zanui.com.au>


### PR DESCRIPTION
mostly there are three changes:
- change from `%w()` -> `%w[]`
- change from '%i()' -> `%i[]`

Also, there are twp weird warnings from `spec/`:
```
➜  github-changelog-generator git:(travis-ci-fix) ✗ bundle exec rake
Running RuboCop...
Inspecting 27 files
........................W..

Offenses:

spec/unit/parse_file_spec.rb:17:9: W: Lint/AmbiguousBlockAssociation: Parenthesize the param change { options } to make sure that the block will be associated with the change method call. (https://github.com/bbatsov/ruby-style-guide#syntax)
        expect { parser.parse! }.to_not change { options }
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/unit/parse_file_spec.rb:56:1: C: Style/IndentHeredoc: Use 2 spaces for indentation in a heredoc by using <<~ instead of <<. (https://github.com/bbatsov/ruby-style-guide#squiggly-heredocs)
exclude-labels=73a91042-da6f-11e5-9335-1040f38d7f90,7adf83b4-da6f-11e5-ae18-1040f38d7f90 ...
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

27 files inspected, 2 offenses detected
RuboCop failed!
```
I exclude it but this is opened for discussion. I guess running functional test cases are more important than style check. 