### PR TITLE
Travis: use jruby-9.1.9.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
     - rvm: 2.1
     - rvm: 2.3.4
     - rvm: 2.4.1
-    - rvm: jruby-9.1.8.0
+    - rvm: jruby-9.1.9.0
       jdk: oraclejdk8
       env:
         - JRUBY_OPTS=--debug


### PR DESCRIPTION
This PR updates the CI matrix to use latest stable JRuby.