### PR TITLE
AppVeyor: Windows configuration to pass RuboCop

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![Gem Version](https://badge.fury.io/rb/github_changelog_generator.svg)](http://badge.fury.io/rb/github_changelog_generator)
 [![Dependency Status](https://gemnasium.com/skywinder/github-changelog-generator.svg)](https://gemnasium.com/skywinder/github-changelog-generator)
 [![Build Status](https://travis-ci.org/skywinder/github-changelog-generator.svg?branch=master)](https://travis-ci.org/skywinder/github-changelog-generator)
+[![Build status](https://ci.appveyor.com/api/projects/status/xdfnfmdjfo0upm7m?svg=true)](https://ci.appveyor.com/project/olleolleolle/github-changelog-generator)
 [![Inline docs](http://inch-ci.org/github/skywinder/github-changelog-generator.svg)](http://inch-ci.org/github/skywinder/github-changelog-generator)
 [![Code Climate](https://codeclimate.com/github/skywinder/github-changelog-generator/badges/gpa.svg)](https://codeclimate.com/github/skywinder/github-changelog-generator)
 [![Test Coverage](https://codeclimate.com/github/skywinder/github-changelog-generator/badges/coverage.svg)](https://codeclimate.com/github/skywinder/github-changelog-generator)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,6 +17,9 @@ environment:
     - ruby_version: "21" # Older version, but matches Travis-CI
     - ruby_version: "21-x64"
 
+init:
+  - git config --global core.autocrlf true
+
 install:
   - SET PATH=C:\Ruby%ruby_version%\bin;%PATH%
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -51,3 +51,8 @@ notifications:
       - sky4winder+githubchangeloggenerator@gmail.com
     on_build_success: false
     on_build_status_changed: true
+  - provider: GitHubPullRequest
+    on_build_success: true
+    on_build_failure: true
+    on_build_status_changed: true
+


### PR DESCRIPTION
AppVeyor is a CI service which supports builds on Windows. Currently, RuboCop fails there.

This PR adds the git configuration line that RuboCop asks for in its styleguide.

The build is failing with [Layout/EndOfLine](https://github.com/bbatsov/ruby-style-guide#crlf) warnings: https://ci.appveyor.com/project/olleolleolle/github-changelog-generator/build/job/o2fi6e10230v2e1j

Let's see if this can make it pass.

# Summary

- Git configuration in `init` build step of AppVeyor
- README badge of Windows build status
- AppVeyor GitHubPullRequest notification

# Questions

- Which Windows versions do we want to test? @Arcanemagus kindly added two 2.1 variations when  the composing the initial configuration.