### PR TITLE
AppVeyor: drop init build hook, add .gitattributes instead

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text eol=lf
+

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,9 +17,6 @@ environment:
     - ruby_version: "21" # Older version, but matches Travis-CI
     - ruby_version: "21-x64"
 
-init:
-  - git config --global core.autocrlf true
-
 install:
   - SET PATH=C:\Ruby%ruby_version%\bin;%PATH%
 


### PR DESCRIPTION
This PR introduces `.gitattributes` to avoid extra steps in AppVeyor CI configuration file.

Read more: [Git Book about gitattributes](https://git-scm.com/docs/gitattributes)