### PR TITLE
Add newline after version name and Full Changelog link

### DIFF
--- a/lib/github_changelog_generator/generator/generator_generation.rb
+++ b/lib/github_changelog_generator/generator/generator_generation.rb
@@ -66,7 +66,7 @@ module GitHubChangelogGenerator
       log += if newer_tag_name.equal?(options[:unreleased_label])
                "## [#{newer_tag_name}](#{release_url})\n\n"
              else
-               "## [#{newer_tag_name}](#{release_url}) (#{time_string})\n HELLLOOOOOOOO"
+               "## [#{newer_tag_name}](#{release_url}) (#{time_string})\n\n"
              end
 
       if options[:compare_link] && older_tag_link

--- a/lib/github_changelog_generator/generator/generator_generation.rb
+++ b/lib/github_changelog_generator/generator/generator_generation.rb
@@ -66,7 +66,7 @@ module GitHubChangelogGenerator
       log += if newer_tag_name.equal?(options[:unreleased_label])
                "## [#{newer_tag_name}](#{release_url})\n\n"
              else
-               "## [#{newer_tag_name}](#{release_url}) (#{time_string})\n"
+               "## [#{newer_tag_name}](#{release_url}) (#{time_string})\n HELLLOOOOOOOO"
              end
 
       if options[:compare_link] && older_tag_link


### PR DESCRIPTION
Added a new line between the version and Full Changelog links.

This improves the Markdown, so that more Markdown parsers can do the right thing with this.