### PR TITLE
Travis: update CI matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,16 +6,16 @@ before_install:
   - gem install bundler
 matrix:
   include:
-    - rvm: 2.2.7
+    - rvm: 2.2.8
       install: true # This skips 'bundle install'
       script: gem build github_changelog_generator && gem install *.gem
-    - rvm: 2.2.7
+    - rvm: 2.2.8
       install: true # This skips 'bundle install'
       script: gem build github_changelog_generator && bundle install
       gemfile: spec/install-gem-in-bundler.gemfile
-    - rvm: 2.3.4
-    - rvm: 2.4.1
-    - rvm: jruby-9.1.12.0
+    - rvm: 2.3.5
+    - rvm: 2.4.2
+    - rvm: jruby-9.1.13.0
       jdk: oraclejdk8
       env:
         - JRUBY_OPTS=--debug


### PR DESCRIPTION
This PR updates the CI matrix to use 

- Ruby 2.2.8, 2.3.5 and 2.4.2

---

This can be merged when `rvm` supports these versions.
