### PR TITLE
Travis: use JRuby 9.1.13.0; don't redo rvm's job

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,7 +26,7 @@ Metrics/ClassLength:
 Metrics/MethodLength:
     Enabled: false
 
-Style/FileName:
+Naming/FileName:
     Exclude:
       - 'bin/git-generate-changelog'
 
@@ -36,7 +36,7 @@ Metrics/AbcSize:
   Enabled: false
 
 # Offense count: 1
-Style/AccessorMethodName:
+Naming/AccessorMethodName:
   Enabled: false
 
 # Offense count: 10
@@ -75,3 +75,8 @@ Style/SafeNavigation:
 Metrics/BlockLength:
   Exclude:
     - 'spec/**/*'
+
+# Re-enable when merged; https://github.com/bbatsov/rubocop/pull/4756
+Lint/InterpolationCheck:
+  Enabled: false
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ matrix:
         - DEBUG=1
   allow_failures:
     - rvm: jruby-head
+  fast_finish: true
 
 addons:
   code_climate:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: ruby
 cache:
   - bundler
 before_install:
-  - gem update --system
   - gem install bundler
 matrix:
   include:
@@ -15,7 +14,7 @@ matrix:
       gemfile: spec/install-gem-in-bundler.gemfile
     - rvm: 2.3.4
     - rvm: 2.4.1
-    - rvm: jruby-9.1.12.0
+    - rvm: jruby-9.1.13.0
       jdk: oraclejdk8
       env:
         - JRUBY_OPTS=--debug

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ group :development, :test do
   gem "bundler"
   gem "overcommit", ">= 0.31"
   gem "rake"
-  gem "rubocop", ">= 0.43"
+  gem "rubocop", ">= 0.50"
 end
 
 group :development do

--- a/github_changelog_generator.gemspec
+++ b/github_changelog_generator.gemspec
@@ -1,4 +1,3 @@
-# coding: utf-8
 # frozen_string_literal: true
 
 lib = File.expand_path("../lib", __FILE__)

--- a/lib/github_changelog_generator/generator/generator_fetcher.rb
+++ b/lib/github_changelog_generator/generator/generator_fetcher.rb
@@ -78,7 +78,7 @@ module GitHubChangelogGenerator
           issue["actual_date"] = commit["commit"]["author"]["date"]
 
           # issue['actual_date'] = commit['author']['date']
-        rescue
+        rescue StandardError
           puts "Warning: Can't fetch commit #{event['commit_id']}. It is probably referenced from another repo."
           issue["actual_date"] = issue["closed_at"]
         end

--- a/lib/github_changelog_generator/parser.rb
+++ b/lib/github_changelog_generator/parser.rb
@@ -277,7 +277,7 @@ module GitHubChangelogGenerator
 
         begin
           param = match[2].nil?
-        rescue
+        rescue StandardError
           puts "Can't detect user and name from first parameter: '#{arg0}' -> exit'"
           return
         end

--- a/lib/github_changelog_generator/parser_file.rb
+++ b/lib/github_changelog_generator/parser_file.rb
@@ -48,7 +48,7 @@ module GitHubChangelogGenerator
       return if non_configuration_line?(line)
       option_name, value = extract_pair(line)
       @options[option_key_for(option_name)] = convert_value(value, option_name)
-    rescue
+    rescue StandardError
       raise ParserError, "Failed on line ##{line_number}: \"#{line.gsub(/[\n\r]+/, '')}\""
     end
 


### PR DESCRIPTION
This CI-configuring PR:

- updates to [JRuby 9.1.13.0](http://jruby.org/2017/09/06/jruby-9-1-13-0.html)
- updates to [RuboCop 0.50.0](https://github.com/bbatsov/rubocop/releases/tag/v0.50.0) (skipping a rule to be able to)
- skips a step that [`rvm` is already doing](https://github.com/rvm/rvm/pull/4142): `gem update --system`.
- configures the CI matrix to [`fast_finish: true`](https://blog.travis-ci.com/2013-11-27-fast-finishing-builds/)

You can learn more about the features used by navigating to the links.