### PR TITLE
Travis: Configure cache: bundler: true

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 cache:
-  - bundler
+  bundler: true
 before_install:
   - gem install bundler
 matrix:


### PR DESCRIPTION
This PR configures Travis `cache` so that Bundler's downloads will be cached.

<details>

```
$ bundle install --jobs=3 --retry=3 --path=${BUNDLE_PATH:-vendor/bundle}

Fetching gem metadata from https://rubygems.org/...........
Fetching version metadata from https://rubygems.org/..
Fetching dependency metadata from https://rubygems.org/.
Resolving dependencies.........
Using concurrent-ruby 1.0.5 (java)
Using i18n 0.8.6
Using minitest 5.10.3
Using rake 12.1.0
Using public_suffix 3.0.0
Using thread_safe 0.3.6 (java)
Using ast 2.3.0
Using bump 0.5.4
Using bundler 1.15.4
Using docile 1.1.5
Using ffi 1.9.18 (java)
Using json 2.1.0 (java)
Using tins 1.15.0
Using simplecov-html 0.10.2
Using thor 0.19.4
Using safe_yaml 1.0.4
Using multipart-post 2.0.0
Using multi_json 1.12.2
Using retriable 3.1.1
Using hashdiff 0.3.6
Using diff-lcs 1.3
Using iniparse 1.4.4
Using parallel 1.12.0
Using powerpack 0.1.1
Using ruby-progressbar 1.8.3
Using rspec-support 3.6.0
Using vcr 3.0.3
Using unicode-display_width 1.3.0
Using rainbow 2.2.2
Using addressable 2.5.2
Using tzinfo 1.2.3
Using parser 2.4.0.0
Using childprocess 0.7.1
Using simplecov 0.14.1
Using term-ansicolor 1.6.0
Using crack 0.4.3
Using faraday 0.13.1
Using rspec-core 3.6.0
Using rspec-expectations 3.6.0
Using rspec-mocks 3.6.0
Using activesupport 5.1.4
Using rubocop 0.50.0
Using overcommit 0.41.0
Using codeclimate-test-reporter 1.0.7
Using coveralls 0.8.21
Using webmock 3.0.1
Using faraday-http-cache 2.0.0
Using sawyer 0.8.1
Using rspec 3.6.0
Using octokit 4.7.0
Using github_changelog_generator 1.14.3 from source at `.`
Bundle complete! 14 Gemfile dependencies, 51 gems now installed.
Bundled gems are installed into ./vendor/bundle.
```

<summary>This is what it looks like now in the CI</summary>

</details>