### PR TITLE
filter tags correctly when `since_tag` is set to most recent tag

### DIFF
--- a/lib/github_changelog_generator/generator/generator_tags.rb
+++ b/lib/github_changelog_generator/generator/generator_tags.rb
@@ -129,7 +129,7 @@ module GitHubChangelogGenerator
       if tag
         if all_tags.map { |t| t["name"] }.include? tag
           idx = all_tags.index { |t| t["name"] == tag }
-          filtered_tags = if idx.present?
+          filtered_tags = if idx
                             all_tags[0..idx]
                           else
                             []

--- a/lib/github_changelog_generator/generator/generator_tags.rb
+++ b/lib/github_changelog_generator/generator/generator_tags.rb
@@ -129,7 +129,7 @@ module GitHubChangelogGenerator
       if tag
         if all_tags.map { |t| t["name"] }.include? tag
           idx = all_tags.index { |t| t["name"] == tag }
-          filtered_tags = if idx > 0
+          filtered_tags = if idx.present?
                             all_tags[0..idx]
                           else
                             []

--- a/spec/unit/generator/generator_tags_spec.rb
+++ b/spec/unit/generator/generator_tags_spec.rb
@@ -182,6 +182,11 @@ describe GitHubChangelogGenerator::Generator do
         let(:generator) { GitHubChangelogGenerator::Generator.new(since_tag: "2") }
         it { is_expected.to be_a Array }
         it { is_expected.to match_array(tags_from_strings(%w[1 2])) }
+
+        context "with since tag set to the most recent tag" do
+          let(:generator) { GitHubChangelogGenerator::Generator.new(since_tag: "1") }
+          it { is_expected.to match_array(tags_from_strings(%w[1])) }
+        end
       end
 
       context "with invalid since tag" do


### PR DESCRIPTION
Hey,
before this fix [`filtered_tags`](https://github.com/skywinder/github-changelog-generator/blob/master/lib/github_changelog_generator/generator/generator_generation.rb#L132) was empty which caused a fallback to the last tag in the sorted_tags array (which is the oldest tag).
There for no issues and PRs were filtered in that case.

fixes #555
fixes #304