### PR TITLE
Add option --require to load custom Ruby code before starting

### DIFF
--- a/lib/github_changelog_generator/generator/generator_generation.rb
+++ b/lib/github_changelog_generator/generator/generator_generation.rb
@@ -6,6 +6,7 @@ module GitHubChangelogGenerator
     #
     # @return [String] Generated change log file
     def compound_changelog
+      options.load_custom_ruby_files
       fetch_and_filter_tags
       fetch_issues_and_pr
 

--- a/lib/github_changelog_generator/options.rb
+++ b/lib/github_changelog_generator/options.rb
@@ -43,6 +43,7 @@ module GitHubChangelogGenerator
       pulls
       release_branch
       release_url
+      require
       simple_list
       since_tag
       ssl_ca_file
@@ -67,6 +68,13 @@ module GitHubChangelogGenerator
 
     def to_hash
       values
+    end
+
+    # Loads the configured Ruby files from the --require option.
+    #
+    # @return [void]
+    def load_custom_ruby_files
+      self[:require].each { |f| require f }
     end
 
     private

--- a/lib/github_changelog_generator/parser.rb
+++ b/lib/github_changelog_generator/parser.rb
@@ -181,6 +181,9 @@ module GitHubChangelogGenerator
         opts.on("--ssl-ca-file [PATH]", "Path to cacert.pem file. Default is a bundled lib/github_changelog_generator/ssl_certs/cacert.pem. Respects SSL_CA_PATH.") do |ssl_ca_file|
           options[:ssl_ca_file] = ssl_ca_file
         end
+        opts.on("--require x,y,z", Array, "Path to Ruby file(s) to require.") do |paths|
+          options[:require] = paths
+        end
         opts.on("--[no-]verbose", "Run verbosely. Default is true") do |v|
           options[:verbose] = v
         end
@@ -226,7 +229,8 @@ module GitHubChangelogGenerator
         bug_prefix: "**Fixed bugs:**",
         enhancement_prefix: "**Implemented enhancements:**",
         breaking_prefix: "**Breaking changes:**",
-        http_cache: true
+        http_cache: true,
+        require: []
       )
     end
   end

--- a/man/git-generate-changelog.1
+++ b/man/git-generate-changelog.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-GENERATE\-CHANGELOG" "1" "December 2016" "" ""
+.TH "GIT\-GENERATE\-CHANGELOG" "1" "October 2017" "" ""
 .
 .SH "NAME"
 \fBgit\-generate\-changelog\fR \- Generate changelog from github
@@ -175,12 +175,6 @@ Issues with the specified labels will be always added to "Fixed bugs" section\. 
 Issues with the specified labels will be always added to "Implemented enhancements" section\. Default is \'enhancement,Enhancement\'
 .
 .P
-\-\-between\-tags x,y,z
-.
-.P
-Change log will be filled only between specified tags
-.
-.P
 \-\-exclude\-tags x,y,z
 .
 .P
@@ -263,6 +257,25 @@ Filename to use for cache\. Default is github\-changelog\-http\-cache in a tempo
 .
 .P
 Filename to use for cache log\. Default is github\-changelog\-logger\.log in a temporary directory\.
+.
+.IP "" 4
+.
+.nf
+
+\-\-ssl\-ca\-file [PATH]
+.
+.fi
+.
+.IP "" 0
+.
+.P
+Path to cacert\.pem file\. Default is a bundled lib/github_changelog_generator/ssl_certs/cacert\.pem\. Respects SSL_CA_PATH\.
+.
+.P
+\-\-require file1\.rb,file2\.rb
+.
+.P
+Paths to Ruby file(s) to require before generating changelog\.
 .
 .P
 \-\-[no\-]verbose

--- a/man/git-generate-changelog.1.html
+++ b/man/git-generate-changelog.1.html
@@ -248,6 +248,15 @@
 
 <p>   Filename to use for cache log. Default is github-changelog-logger.log in a temporary directory.</p>
 
+<pre><code>--ssl-ca-file [PATH]
+</code></pre>
+
+<p>   Path to cacert.pem file. Default is a bundled lib/github_changelog_generator/ssl_certs/cacert.pem. Respects SSL_CA_PATH.</p>
+
+<p>   --require file1.rb,file2.rb</p>
+
+<p>   Paths to Ruby file(s) to require before generating changelog.</p>
+
 <p>   --[no-]verbose</p>
 
 <p>   Run verbosely. Default is true</p>
@@ -277,7 +286,7 @@
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>December 2016</li>
+    <li class='tc'>October 2017</li>
     <li class='tr'>git-generate-changelog(1)</li>
   </ol>
 

--- a/man/git-generate-changelog.md
+++ b/man/git-generate-changelog.md
@@ -177,7 +177,11 @@ Automatically generate change log from your tags, issues, labels and pull reques
 
     --ssl-ca-file [PATH]
 
-   Path to cacert.pem file. Default is a bundled lib/github_changelog_generator/ssl_certs/cacert.pem.  Respects SSL_CA_PATH.
+   Path to cacert.pem file. Default is a bundled lib/github_changelog_generator/ssl_certs/cacert.pem. Respects SSL_CA_PATH.
+
+   --require file1.rb,file2.rb
+
+   Paths to Ruby file(s) to require before generating changelog.
 
    --[no-]verbose
 


### PR DESCRIPTION
This PR adds a feature and an option `--require`: it takes a comma-separated list of paths to custom Ruby files to `require`. This happens just before starting the changelog generation.

Example:

```
github_changelog_generator --require ./.changelog_hacks.rb,./.changelog_hacks2.rb
```

- [x] documentation of the new option