### PR TITLE
Aborting on missing --user and --project prints all of usage

### DIFF
--- a/lib/github_changelog_generator/parser.rb
+++ b/lib/github_changelog_generator/parser.rb
@@ -20,7 +20,7 @@ module GitHubChangelogGenerator
         abort [e, parser].join("\n")
       end
 
-      abort(parser.banner) unless options[:user] && options[:project]
+      abort(parser.to_s) unless options[:user] && options[:project]
 
       options.print_options
 
@@ -33,17 +33,17 @@ module GitHubChangelogGenerator
     # @return [OptionParser]
     def self.setup_parser(options)
       OptionParser.new do |opts| # rubocop:disable Metrics/BlockLength
-        opts.banner = "Usage: github_changelog_generator [options]"
-        opts.on("-u", "--user [USER]", "Username of the owner of target GitHub repo") do |last|
+        opts.banner = "Usage: github_changelog_generator --user USER --project PROJECT [options]"
+        opts.on("-u", "--user USER", "Username of the owner of target GitHub repo") do |last|
           options[:user] = last
         end
-        opts.on("-p", "--project [PROJECT]", "Name of project on GitHub") do |last|
+        opts.on("-p", "--project PROJECT", "Name of project on GitHub") do |last|
           options[:project] = last
         end
         opts.on("-t", "--token [TOKEN]", "To make more than 50 requests per hour your GitHub token is required. You can generate it at: https://github.com/settings/tokens/new") do |last|
           options[:token] = last
         end
-        opts.on("-f", "--date-format [FORMAT]", "Date format. Default is %Y-%m-%d") do |last|
+        opts.on("-f", "--date-format FORMAT", "Date format. Default is %Y-%m-%d") do |last|
           options[:date_format] = last
         end
         opts.on("-o", "--output [NAME]", "Output file. Default is CHANGELOG.md") do |last|

--- a/lib/github_changelog_generator/parser.rb
+++ b/lib/github_changelog_generator/parser.rb
@@ -21,7 +21,8 @@ module GitHubChangelogGenerator
       end
 
       unless options[:user] && options[:project]
-        warn "Tell us which user and project to work on. Options --user and --project, or settings to that effect."
+        warn "Configure which user and project to work on."
+        warn "Options --user and --project, or settings to that effect. See --help for more."
         abort(parser.banner) 
       end
 

--- a/lib/github_changelog_generator/parser.rb
+++ b/lib/github_changelog_generator/parser.rb
@@ -22,7 +22,7 @@ module GitHubChangelogGenerator
 
       unless options[:user] && options[:project]
         warn "Tell us which user and project to work on. Options --user and --project, or settings to that effect."
-        abort(parser.to_s) 
+        abort(parser.banner) 
       end
 
       options.print_options

--- a/lib/github_changelog_generator/parser.rb
+++ b/lib/github_changelog_generator/parser.rb
@@ -20,7 +20,10 @@ module GitHubChangelogGenerator
         abort [e, parser].join("\n")
       end
 
-      abort(parser.to_s) unless options[:user] && options[:project]
+      unless options[:user] && options[:project]
+        warn "Tell us which user and project to work on. Options --user and --project, or settings to that effect."
+        abort(parser.to_s) 
+      end
 
       options.print_options
 

--- a/lib/github_changelog_generator/parser.rb
+++ b/lib/github_changelog_generator/parser.rb
@@ -23,7 +23,7 @@ module GitHubChangelogGenerator
       unless options[:user] && options[:project]
         warn "Configure which user and project to work on."
         warn "Options --user and --project, or settings to that effect. See --help for more."
-        abort(parser.banner) 
+        abort(parser.banner)
       end
 
       options.print_options


### PR DESCRIPTION
Thanks to investigations by @Furtif, this PR adds clarity to the abort message which happens if there's no user or project information after options and configurations have been parsed.

Before this change, the abort would print out only the name of the program and the "usage", which was incredibly bare.

- [ ] Explain to the user why their invocation did not work: "Tell us which user and project to work on. Options --user and --project, or settings to that effect."

See #577 