### PR TITLE
Add Rake options reported missing

### DIFF
--- a/lib/github_changelog_generator/task.rb
+++ b/lib/github_changelog_generator/task.rb
@@ -10,6 +10,7 @@ module GitHubChangelogGenerator
 
     OPTIONS = %w[ user project token date_format output
                   bug_prefix enhancement_prefix issue_prefix
+                  breaking_labels issue_line_labels
                   header merge_prefix issues
                   add_issues_wo_labels add_pr_wo_labels
                   pulls filter_issues_by_milestone author


### PR DESCRIPTION
This PR is in response to #583, adding two missing options to the Rake task.

There may be more missing.

Fixes #583 