### PR TITLE
RuboCop 0.52.0 linting

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -80,3 +80,10 @@ Metrics/BlockLength:
 Lint/InterpolationCheck:
   Enabled: false
 
+Style/FormatStringToken:
+  Exclude:
+    - lib/github_changelog_generator/parser.rb
+
+Style/MixinUsage:
+  Exclude:
+    - lib/github_changelog_generator/task.rb

--- a/github_changelog_generator.gemspec
+++ b/github_changelog_generator.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.version            = GitHubChangelogGenerator::VERSION
   spec.default_executable = "github_changelog_generator"
 
-  spec.required_ruby_version = ">= 1.9.3"
+  spec.required_ruby_version = ">= 2.2.2"
   spec.authors = ["Petr Korolev", "Olle Jonsson"]
   spec.email = "sky4winder+github_changelog_generator@gmail.com"
 


### PR DESCRIPTION
This PR makes the linting pass with RuboCop 0.52.0.

One change which came to light was that the code was being checked for 2.2 syntax, but was promising 1.9 syntax (which is no longer checkable using RuboCop).

I propose this change:

- gemspec: Make 2.2.2 the earliest-supported Ruby version

Some other linting seemed to be wrong, or not something I want to do.

<details>


```
lib/github_changelog_generator/parser.rb:50:78: C: Style/FormatStringToken: Prefer annotated tokens (like %<foo>s) over unannotated tokens (like %s).
        opts.on("-f", "--date-format FORMAT", "Date format. Default is %Y-%m-%d") do |last|
                                                                             ^^
lib/github_changelog_generator/parser.rb:196:29: C: Style/FormatStringToken: Prefer annotated tokens (like %<foo>s) over unannotated tokens (like %s).
        date_format: "%Y-%m-%d",
                            ^^
lib/github_changelog_generator/task.rb:9:5: C: Style/MixinUsage: include is used at the top level. Use inside class or module.
    include ::Rake::DSL if defined?(::Rake::DSL)
    ^^^^^^^^^^^^^^^^^^^
```

</details>