### PR TITLE
Fix unlabeled, mixed labels, and unmapped labels handling

### DIFF
--- a/lib/github_changelog_generator/generator/generator.rb
+++ b/lib/github_changelog_generator/generator/generator.rb
@@ -89,7 +89,7 @@ module GitHubChangelogGenerator
           older_tag["name"]
         end
 
-      Entry.new(options).create_entry_for_tag(filtered_pull_requests, filtered_issues, newer_tag_name, newer_tag_link, newer_tag_time, older_tag_name)
+      Entry.new(options).generate_entry_for_tag(filtered_pull_requests, filtered_issues, newer_tag_name, newer_tag_link, newer_tag_time, older_tag_name)
     end
 
     # Filters issues and pull requests based on, respectively, `closed_at` and `merged_at`

--- a/lib/github_changelog_generator/generator/generator_processor.rb
+++ b/lib/github_changelog_generator/generator/generator_processor.rb
@@ -161,7 +161,7 @@ module GitHubChangelogGenerator
       else
         issues.select do |issue|
           labels = issue["labels"].map { |l| l["name"] } & options[:include_labels]
-          labels.any?
+          labels.any? || issue["labels"].empty?
         end
       end
     end

--- a/lib/github_changelog_generator/generator/section.rb
+++ b/lib/github_changelog_generator/generator/section.rb
@@ -15,8 +15,8 @@ module GitHubChangelogGenerator
       @options = opts[:options] || Options.new({})
     end
 
-    # @param [Array] issues List of issues on sub-section
-    # @param [String] prefix Name of sub-section
+    # Returns the content of a section.
+    #
     # @return [String] Generate section content
     def generate_content
       content = ""

--- a/lib/github_changelog_generator/parser.rb
+++ b/lib/github_changelog_generator/parser.rb
@@ -116,10 +116,10 @@ module GitHubChangelogGenerator
         opts.on("--[no-]compare-link", "Include compare link (Full Changelog) between older version and newer version. Default is true") do |v|
           options[:compare_link] = v
         end
-        opts.on("--include-labels  x,y,z", Array, "Only issues with the specified labels will be included in the changelog.") do |list|
+        opts.on("--include-labels  x,y,z", Array, "Of the labeled issues, only include the ones with the given labels.") do |list|
           options[:include_labels] = list
         end
-        opts.on("--exclude-labels  x,y,z", Array, "Issues with the specified labels will be always excluded from changelog. Default is 'duplicate,question,invalid,wontfix'") do |list|
+        opts.on("--exclude-labels  x,y,z", Array, "Issues with the specified labels will be excluded from changelog. Default is 'duplicate,question,invalid,wontfix'") do |list|
           options[:exclude_labels] = list
         end
         opts.on("--bug-labels  x,y,z", Array, 'Issues with the specified labels will be always added to "Fixed bugs" section. Default is \'bug,Bug\'') do |list|

--- a/spec/unit/generator/entry_spec.rb
+++ b/spec/unit/generator/entry_spec.rb
@@ -24,7 +24,8 @@ module GitHubChangelogGenerator
         "labels" => labels.map { |l| label(l) },
         "number" => number,
         "html_url" => "https://github.com/owner/repo/pull/#{number}",
-        "user" => user.merge("html_url" => "https://github.com/#{user['login']}")
+        "user" => user.merge("html_url" => "https://github.com/#{user['login']}"),
+        "merged_at" => Time.now.utc
       }
     end
 
@@ -36,71 +37,179 @@ module GitHubChangelogGenerator
       %w[enhancements bugs breaking issues]
     end
 
-    describe "#create_entry_for_tag" do
-      let(:options) do
-        Parser.default_options.merge(
-          user: "owner",
-          project: "repo",
-          bug_labels: ["bug"],
-          enhancement_labels: ["enhancement"],
-          breaking_labels: ["breaking"]
-        )
-      end
+    # Default to no issues or PRs.
+    let(:issues) { [] }
+    let(:pull_requests) { [] }
 
+    # Default to standard options minus verbose to avoid output during testing.
+    let(:options) do
+      Parser.default_options.merge(verbose: false)
+    end
+
+    # Mock out fake github fetching for the issues/pull_requests lets and then
+    # expose filtering from the GitHubChangelogGenerator::Generator class
+    # instance for end-to-end entry testing.
+    let(:generator) do
+      fake_fetcher = instance_double(
+        "fetcher",
+        fetch_closed_issues_and_pr: [issues, pull_requests],
+        fetch_closed_pull_requests: [],
+        fetch_events_async: issues + pull_requests
+      )
+      allow(GitHubChangelogGenerator::OctoFetcher).to receive(:new).and_return(fake_fetcher)
+      generator = GitHubChangelogGenerator::Generator.new(options)
+      generator.send(:fetch_issues_and_pr)
+      generator
+    end
+    let(:filtered_issues) do
+      generator.instance_variable_get :@issues
+    end
+    let(:filtered_pull_requests) do
+      generator.instance_variable_get :@pull_requests
+    end
+    let(:entry_sections) do
+      subject.send(:create_sections)
+      # In normal usage, the entry generation would have received filtered
+      # issues and pull requests so replicate that here for ease of testing.
+      subject.send(:sort_into_sections, filtered_pull_requests, filtered_issues)
+      subject.instance_variable_get :@sections
+    end
+
+    describe "#generate_entry_for_tag" do
       let(:issues) do
         [
           issue("no labels", [], "5", "login" => "user1"),
           issue("enhancement", ["enhancement"], "6", "login" => "user2"),
           issue("bug", ["bug"], "7", "login" => "user1"),
           issue("breaking", ["breaking"], "8", "login" => "user5"),
-          issue("all the labels", %w[enhancement bug breaking], "9", "login" => "user9")
+          issue("all the labels", %w[enhancement bug breaking], "9", "login" => "user9"),
+          issue("all the labels different order", %w[breaking enhancement bug], "10", "login" => "user5"),
+          issue("some unmapped labels", %w[tests-fail bug], "11", "login" => "user5"),
+          issue("no mapped labels", %w[docs maintenance], "12", "login" => "user5")
         ]
       end
 
       let(:pull_requests) do
         [
-          pr("no labels", [], "10", "login" => "user1"),
-          pr("enhancement", ["enhancement"], "11", "login" => "user5"),
-          pr("bug", ["bug"], "12", "login" => "user5"),
-          pr("breaking", ["breaking"], "13", "login" => "user5"),
-          pr("all the labels", %w[enhancement bug breaking], "14", "login" => "user5")
+          pr("no labels", [], "20", "login" => "user1"),
+          pr("enhancement", ["enhancement"], "21", "login" => "user5"),
+          pr("bug", ["bug"], "22", "login" => "user5"),
+          pr("breaking", ["breaking"], "23", "login" => "user5"),
+          pr("all the labels", %w[enhancement bug breaking], "24", "login" => "user5"),
+          pr("all the labels different order", %w[breaking enhancement bug], "25", "login" => "user5"),
+          pr("some unmapped labels", %w[tests-fail bug], "26", "login" => "user5"),
+          pr("no mapped labels", %w[docs maintenance], "27", "login" => "user5")
         ]
       end
 
       subject { described_class.new(options) }
-      it "generates a header and body" do
-        changelog = <<-CHANGELOG.gsub(/^ {8}/, "")
-        ## [1.0.1](https://github.com/owner/repo/tree/1.0.1) (2017-12-04)
+      describe "include issues without labels" do
+        let(:options) do
+          Parser.default_options.merge(
+            user: "owner",
+            project: "repo",
+            bug_labels: ["bug"],
+            enhancement_labels: ["enhancement"],
+            breaking_labels: ["breaking"],
+            verbose: false
+          )
+        end
 
-        [Full Changelog](https://github.com/owner/repo/compare/1.0.0...1.0.1)
+        it "generates a header and body" do
+          changelog = <<-CHANGELOG.gsub(/^ {10}/, "")
+          ## [1.0.1](https://github.com/owner/repo/tree/1.0.1) (2017-12-04)
 
-        **Breaking changes:**
+          [Full Changelog](https://github.com/owner/repo/compare/1.0.0...1.0.1)
 
-        - issue breaking [\\#8](https://github.com/owner/repo/issue/8)
-        - pr breaking [\\#13](https://github.com/owner/repo/pull/13) ([user5](https://github.com/user5))
+          **Breaking changes:**
 
-        **Implemented enhancements:**
+          - issue breaking [\\#8](https://github.com/owner/repo/issue/8)
+          - issue all the labels [\\#9](https://github.com/owner/repo/issue/9)
+          - issue all the labels different order [\\#10](https://github.com/owner/repo/issue/10)
+          - pr breaking [\\#23](https://github.com/owner/repo/pull/23) ([user5](https://github.com/user5))
+          - pr all the labels [\\#24](https://github.com/owner/repo/pull/24) ([user5](https://github.com/user5))
+          - pr all the labels different order [\\#25](https://github.com/owner/repo/pull/25) ([user5](https://github.com/user5))
 
-        - issue enhancement [\\#6](https://github.com/owner/repo/issue/6)
-        - issue all the labels [\\#9](https://github.com/owner/repo/issue/9)
-        - pr enhancement [\\#11](https://github.com/owner/repo/pull/11) ([user5](https://github.com/user5))
-        - pr all the labels [\\#14](https://github.com/owner/repo/pull/14) ([user5](https://github.com/user5))
+          **Implemented enhancements:**
 
-        **Fixed bugs:**
+          - issue enhancement [\\#6](https://github.com/owner/repo/issue/6)
+          - pr enhancement [\\#21](https://github.com/owner/repo/pull/21) ([user5](https://github.com/user5))
 
-        - issue bug [\\#7](https://github.com/owner/repo/issue/7)
-        - pr bug [\\#12](https://github.com/owner/repo/pull/12) ([user5](https://github.com/user5))
+          **Fixed bugs:**
 
-        **Closed issues:**
+          - issue bug [\\#7](https://github.com/owner/repo/issue/7)
+          - issue some unmapped labels [\\#11](https://github.com/owner/repo/issue/11)
+          - pr bug [\\#22](https://github.com/owner/repo/pull/22) ([user5](https://github.com/user5))
+          - pr some unmapped labels [\\#26](https://github.com/owner/repo/pull/26) ([user5](https://github.com/user5))
 
-        - issue no labels [\\#5](https://github.com/owner/repo/issue/5)
+          **Closed issues:**
 
-        **Merged pull requests:**
+          - issue no labels [\\#5](https://github.com/owner/repo/issue/5)
+          - issue no mapped labels [\\#12](https://github.com/owner/repo/issue/12)
 
-        - pr no labels [\\#10](https://github.com/owner/repo/pull/10) ([user1](https://github.com/user1))
+          **Merged pull requests:**
 
-        CHANGELOG
-        expect(subject.create_entry_for_tag(pull_requests, issues, "1.0.1", "1.0.1", Time.new(2017, 12, 4), "1.0.0")).to eq(changelog)
+          - pr no labels [\\#20](https://github.com/owner/repo/pull/20) ([user1](https://github.com/user1))
+          - pr no mapped labels [\\#27](https://github.com/owner/repo/pull/27) ([user5](https://github.com/user5))
+
+          CHANGELOG
+
+          expect(subject.generate_entry_for_tag(pull_requests, issues, "1.0.1", "1.0.1", Time.new(2017, 12, 4).utc, "1.0.0")).to eq(changelog)
+        end
+      end
+      describe "exclude issues without labels" do
+        let(:options) do
+          Parser.default_options.merge(
+            user: "owner",
+            project: "repo",
+            bug_labels: ["bug"],
+            enhancement_labels: ["enhancement"],
+            breaking_labels: ["breaking"],
+            add_pr_wo_labels: false,
+            add_issues_wo_labels: false,
+            verbose: false
+          )
+        end
+
+        it "generates a header and body" do
+          changelog = <<-CHANGELOG.gsub(/^ {10}/, "")
+          ## [1.0.1](https://github.com/owner/repo/tree/1.0.1) (2017-12-04)
+
+          [Full Changelog](https://github.com/owner/repo/compare/1.0.0...1.0.1)
+
+          **Breaking changes:**
+
+          - issue breaking [\\#8](https://github.com/owner/repo/issue/8)
+          - issue all the labels [\\#9](https://github.com/owner/repo/issue/9)
+          - issue all the labels different order [\\#10](https://github.com/owner/repo/issue/10)
+          - pr breaking [\\#23](https://github.com/owner/repo/pull/23) ([user5](https://github.com/user5))
+          - pr all the labels [\\#24](https://github.com/owner/repo/pull/24) ([user5](https://github.com/user5))
+          - pr all the labels different order [\\#25](https://github.com/owner/repo/pull/25) ([user5](https://github.com/user5))
+
+          **Implemented enhancements:**
+
+          - issue enhancement [\\#6](https://github.com/owner/repo/issue/6)
+          - pr enhancement [\\#21](https://github.com/owner/repo/pull/21) ([user5](https://github.com/user5))
+
+          **Fixed bugs:**
+
+          - issue bug [\\#7](https://github.com/owner/repo/issue/7)
+          - issue some unmapped labels [\\#11](https://github.com/owner/repo/issue/11)
+          - pr bug [\\#22](https://github.com/owner/repo/pull/22) ([user5](https://github.com/user5))
+          - pr some unmapped labels [\\#26](https://github.com/owner/repo/pull/26) ([user5](https://github.com/user5))
+
+          **Closed issues:**
+
+          - issue no mapped labels [\\#12](https://github.com/owner/repo/issue/12)
+
+          **Merged pull requests:**
+
+          - pr no mapped labels [\\#27](https://github.com/owner/repo/pull/27) ([user5](https://github.com/user5))
+
+          CHANGELOG
+
+          expect(subject.generate_entry_for_tag(pull_requests, issues, "1.0.1", "1.0.1", Time.new(2017, 12, 4).utc, "1.0.0")).to eq(changelog)
+        end
       end
     end
     describe "#parse_sections" do
@@ -184,14 +293,15 @@ module GitHubChangelogGenerator
       end
     end
 
-    describe "#parse_by_sections" do
+    describe "#sort_into_sections" do
       context "default sections" do
         let(:options) do
-          {
+          Parser.default_options.merge(
             bug_labels: ["bug"],
             enhancement_labels: ["enhancement"],
-            breaking_labels: ["breaking"]
-          }
+            breaking_labels: ["breaking"],
+            verbose: false
+          )
         end
 
         let(:issues) do
@@ -200,7 +310,11 @@ module GitHubChangelogGenerator
             issue("enhancement", ["enhancement"]),
             issue("bug", ["bug"]),
             issue("breaking", ["breaking"]),
-            issue("all the labels", %w[enhancement bug breaking])
+            issue("all the labels", %w[enhancement bug breaking]),
+            issue("some unmapped labels", %w[tests-fail bug]),
+            issue("no mapped labels", %w[docs maintenance]),
+            issue("excluded label", %w[wontfix]),
+            issue("excluded and included label", %w[breaking wontfix])
           ]
         end
 
@@ -210,43 +324,45 @@ module GitHubChangelogGenerator
             pr("enhancement", ["enhancement"]),
             pr("bug", ["bug"]),
             pr("breaking", ["breaking"]),
-            pr("all the labels", %w[enhancement bug breaking])
+            pr("all the labels", %w[enhancement bug breaking]),
+            pr("some unmapped labels", %w[tests-fail bug], "15", "login" => "user5"),
+            pr("no mapped labels", %w[docs maintenance], "16", "login" => "user5"),
+            pr("excluded label", %w[wontfix]),
+            pr("excluded and included label", %w[breaking wontfix])
           ]
         end
 
         subject { described_class.new(options) }
 
-        before do
-          subject.send(:set_sections_and_maps)
-          @arr = subject.send(:parse_by_sections, pull_requests, issues)
-        end
-
-        it "returns 4 sections" do
-          expect(@arr.size).to eq 4
+        it "returns 5 sections" do
+          expect(entry_sections.size).to eq 5
         end
 
         it "returns default sections" do
-          default_sections.each { |default_section| expect(@arr.select { |section| section.name == default_section }.size).to eq 1 }
+          default_sections.each { |default_section| expect(entry_sections.select { |section| section.name == default_section }.size).to eq 1 }
         end
 
         it "assigns issues to the correct sections" do
-          breaking_section = @arr.select { |section| section.name == "breaking" }[0]
-          enhancement_section = @arr.select { |section| section.name == "enhancements" }[0]
-          issue_section = @arr.select { |section| section.name == "issues" }[0]
-          bug_section = @arr.select { |section| section.name == "bugs" }[0]
+          breaking_section = entry_sections.select { |section| section.name == "breaking" }[0]
+          enhancement_section = entry_sections.select { |section| section.name == "enhancements" }[0]
+          issue_section = entry_sections.select { |section| section.name == "issues" }[0]
+          bug_section = entry_sections.select { |section| section.name == "bugs" }[0]
+          merged_section = entry_sections.select { |section| section.name == "merged" }[0]
 
-          expect(titles_for(breaking_section.issues)).to eq(["issue breaking", "pr breaking"])
-          expect(titles_for(enhancement_section.issues)).to eq(["issue enhancement", "issue all the labels", "pr enhancement", "pr all the labels"])
-          expect(titles_for(issue_section.issues)).to eq(["issue no labels"])
-          expect(titles_for(bug_section.issues)).to eq(["issue bug", "pr bug"])
-          expect(titles_for(pull_requests)).to eq(["pr no labels"])
+          expect(titles_for(breaking_section.issues)).to eq(["issue breaking", "issue all the labels", "pr breaking", "pr all the labels"])
+          expect(titles_for(enhancement_section.issues)).to eq(["issue enhancement", "pr enhancement"])
+          expect(titles_for(issue_section.issues)).to eq(["issue no labels", "issue no mapped labels"])
+          expect(titles_for(bug_section.issues)).to eq(["issue bug", "issue some unmapped labels", "pr bug", "pr some unmapped labels"])
+          expect(titles_for(merged_section.issues)).to eq(["pr no labels", "pr no mapped labels"])
         end
       end
-      context "configure sections" do
+      context "configure sections and exclude labels" do
         let(:options) do
-          {
-            configure_sections: "{ \"foo\": { \"prefix\": \"foofix\", \"labels\": [\"test1\", \"test2\"]}, \"bar\": { \"prefix\": \"barfix\", \"labels\": [\"test3\", \"test4\"]}}"
-          }
+          Parser.default_options.merge(
+            configure_sections: "{ \"foo\": { \"prefix\": \"foofix\", \"labels\": [\"test1\", \"test2\"]}, \"bar\": { \"prefix\": \"barfix\", \"labels\": [\"test3\", \"test4\"]}}",
+            exclude_labels: ["excluded"],
+            verbose: false
+          )
         end
 
         let(:issues) do
@@ -255,7 +371,9 @@ module GitHubChangelogGenerator
             issue("test1", ["test1"]),
             issue("test3", ["test3"]),
             issue("test4", ["test4"]),
-            issue("all the labels", %w[test1 test2 test3 test4])
+            issue("all the labels", %w[test4 test2 test3 test1]),
+            issue("some excluded labels", %w[excluded test2]),
+            issue("excluded labels", %w[excluded again])
           ]
         end
 
@@ -265,45 +383,46 @@ module GitHubChangelogGenerator
             pr("test1", ["test1"]),
             pr("test3", ["test3"]),
             pr("test4", ["test4"]),
-            pr("all the labels", %w[test1 test2 test3 test4])
+            pr("all the labels", %w[test4 test2 test3 test1]),
+            pr("some excluded labels", %w[excluded test2]),
+            pr("excluded labels", %w[excluded again])
           ]
         end
 
         subject { described_class.new(options) }
 
-        before do
-          subject.send(:set_sections_and_maps)
-          @arr = subject.send(:parse_by_sections, pull_requests, issues)
-        end
-
-        it "returns 2 sections" do
-          expect(@arr.size).to eq 2
+        it "returns 4 sections" do
+          expect(entry_sections.size).to eq 4
         end
 
         it "returns only configured sections" do
-          expect(@arr.select { |section| section.name == "foo" }.size).to eq 1
-          expect(@arr.select { |section| section.name == "bar" }.size).to eq 1
+          expect(entry_sections.select { |section| section.name == "foo" }.size).to eq 1
+          expect(entry_sections.select { |section| section.name == "bar" }.size).to eq 1
         end
 
         it "assigns issues to the correct sections" do
-          foo_section = @arr.select { |section| section.name == "foo" }[0]
-          bar_section = @arr.select { |section| section.name == "bar" }[0]
+          foo_section = entry_sections.select { |section| section.name == "foo" }[0]
+          bar_section = entry_sections.select { |section| section.name == "bar" }[0]
+          issue_section = entry_sections.select { |section| section.name == "issues" }[0]
+          merged_section = entry_sections.select { |section| section.name == "merged" }[0]
 
           aggregate_failures "checks all sections" do
             expect(titles_for(foo_section.issues)).to eq(["issue test1", "issue all the labels", "pr test1", "pr all the labels"])
             expect(titles_for(bar_section.issues)).to eq(["issue test3", "issue test4", "pr test3", "pr test4"])
-            expect(titles_for(pull_requests)).to eq(["pr no labels"])
+            expect(titles_for(merged_section.issues)).to eq(["pr no labels"])
+            expect(titles_for(issue_section.issues)).to eq(["issue no labels"])
           end
         end
       end
       context "add sections" do
         let(:options) do
-          {
+          Parser.default_options.merge(
             bug_labels: ["bug"],
             enhancement_labels: ["enhancement"],
             breaking_labels: ["breaking"],
-            add_sections: "{ \"foo\": { \"prefix\": \"foofix\", \"labels\": [\"test1\", \"test2\"]}}"
-          }
+            add_sections: "{ \"foo\": { \"prefix\": \"foofix\", \"labels\": [\"test1\", \"test2\"]}}",
+            verbose: false
+          )
         end
 
         let(:issues) do
@@ -311,7 +430,10 @@ module GitHubChangelogGenerator
             issue("no labels", []),
             issue("test1", ["test1"]),
             issue("bugaboo", ["bug"]),
-            issue("all the labels", %w[test1 test2 enhancement bug])
+            issue("all the labels", %w[test1 test2 breaking enhancement bug]),
+            issue("default labels first", %w[enhancement bug test1 test2]),
+            issue("some excluded labels", %w[wontfix breaking]),
+            issue("excluded labels", %w[wontfix again])
           ]
         end
 
@@ -320,39 +442,42 @@ module GitHubChangelogGenerator
             pr("no labels", []),
             pr("test1", ["test1"]),
             pr("enhance", ["enhancement"]),
-            pr("all the labels", %w[test1 test2 enhancement bug])
+            pr("all the labels", %w[test1 test2 breaking enhancement bug]),
+            pr("default labels first", %w[enhancement bug test1 test2]),
+            pr("some excluded labels", %w[wontfix breaking]),
+            pr("excluded labels", %w[wontfix again])
           ]
         end
 
         subject { described_class.new(options) }
 
-        before do
-          subject.send(:set_sections_and_maps)
-          @arr = subject.send(:parse_by_sections, pull_requests, issues)
-        end
-
-        it "returns 5 sections" do
-          expect(@arr.size).to eq 5
+        it "returns 6 sections" do
+          expect(entry_sections.size).to eq 6
         end
 
         it "returns default sections" do
-          default_sections.each { |default_section| expect(@arr.select { |section| section.name == default_section }.size).to eq 1 }
+          default_sections.each { |default_section| expect(entry_sections.select { |section| section.name == default_section }.size).to eq 1 }
         end
 
         it "returns added section" do
-          expect(@arr.select { |section| section.name == "foo" }.size).to eq 1
+          expect(entry_sections.select { |section| section.name == "foo" }.size).to eq 1
         end
 
         it "assigns issues to the correct sections" do
-          foo_section = @arr.select { |section| section.name == "foo" }[0]
-          enhancement_section = @arr.select { |section| section.name == "enhancements" }[0]
-          bug_section = @arr.select { |section| section.name == "bugs" }[0]
+          foo_section = entry_sections.select { |section| section.name == "foo" }[0]
+          breaking_section = entry_sections.select { |section| section.name == "breaking" }[0]
+          enhancement_section = entry_sections.select { |section| section.name == "enhancements" }[0]
+          bug_section = entry_sections.select { |section| section.name == "bugs" }[0]
+          issue_section = entry_sections.select { |section| section.name == "issues" }[0]
+          merged_section = entry_sections.select { |section| section.name == "merged" }[0]
 
           aggregate_failures "checks all sections" do
-            expect(titles_for(foo_section.issues)).to eq(["issue test1", "issue all the labels", "pr test1", "pr all the labels"])
-            expect(titles_for(enhancement_section.issues)).to eq(["pr enhance"])
+            expect(titles_for(breaking_section.issues)).to eq(["issue all the labels", "pr all the labels"])
+            expect(titles_for(enhancement_section.issues)).to eq(["issue default labels first", "pr enhance", "pr default labels first"])
             expect(titles_for(bug_section.issues)).to eq(["issue bugaboo"])
-            expect(titles_for(pull_requests)).to eq(["pr no labels"])
+            expect(titles_for(foo_section.issues)).to eq(["issue test1", "pr test1"])
+            expect(titles_for(issue_section.issues)).to eq(["issue no labels"])
+            expect(titles_for(merged_section.issues)).to eq(["pr no labels"])
           end
         end
       end

--- a/spec/unit/generator/generator_processor_spec.rb
+++ b/spec/unit/generator/generator_processor_spec.rb
@@ -2,7 +2,7 @@
 
 module GitHubChangelogGenerator
   describe Generator do
-    let(:default_options) { GitHubChangelogGenerator::Parser.default_options }
+    let(:default_options) { GitHubChangelogGenerator::Parser.default_options.merge(verbose: false) }
     let(:options) { {} }
     let(:generator) { described_class.new(default_options.merge(options)) }
 

--- a/spec/unit/generator/generator_processor_spec.rb
+++ b/spec/unit/generator/generator_processor_spec.rb
@@ -67,11 +67,18 @@ module GitHubChangelogGenerator
 
           it { is_expected.to eq(expected_issues) }
         end
+
+        context "with 'include_labels'" do
+          let(:options) { { add_issues_wo_labels: false, include_labels: %w[GOOD] } }
+          let(:expected_issues) { [good_issue] }
+
+          it { is_expected.to eq(expected_issues) }
+        end
       end
 
       context "when 'include_labels' is specified" do
         let(:options) { { include_labels: %w[GOOD] } }
-        let(:expected_issues) { [good_issue] }
+        let(:expected_issues) { [good_issue, unlabeled_issue] }
 
         it { is_expected.to eq(expected_issues) }
       end

--- a/spec/unit/generator/generator_tags_spec.rb
+++ b/spec/unit/generator/generator_tags_spec.rb
@@ -17,7 +17,7 @@ describe GitHubChangelogGenerator::Generator do
     let(:all_tags) { tags_from_strings(%w[8 7 6 5 4 3 2 1]) }
     let(:sorted_tags) { all_tags }
 
-    let(:default_options) { GitHubChangelogGenerator::Parser.default_options }
+    let(:default_options) { GitHubChangelogGenerator::Parser.default_options.merge(verbose: false) }
     let(:options) { {} }
     let(:generator) { described_class.new(default_options.merge(options)) }
 

--- a/spec/unit/parse_file_spec.rb
+++ b/spec/unit/parse_file_spec.rb
@@ -36,7 +36,7 @@ describe GitHubChangelogGenerator::ParserFile do
     end
 
     context "when override default values" do
-      let(:default_options) { GitHubChangelogGenerator::Parser.default_options }
+      let(:default_options) { GitHubChangelogGenerator::Parser.default_options.merge(verbose: false) }
       let(:options) { {}.merge(default_options) }
       let(:options_before_change) { options.dup }
       let(:file) { StringIO.new("unreleased_label=staging\nunreleased=false\nheader==== Changelog ===") }


### PR DESCRIPTION
- Issues/PRs filtered by --exclude-labels/--include-labels should never be added to sections.
- Issues/PRs with labels mapping to multiple sections should map to default sections order of breaking, then enhancement, then fix.
- Issues/PRs with labels mapping to multiple sections should map to default sections then the first-matching section in --add-sections.
- Issues/PRs with labels mapping to multiple sections should map to the first-matching section in --configure-sections.
- Issues/PRs with some mapped labels and some unmapped labels should respect the mapping rather than behaving like unmapped issues.
- Issues/PRs with only unmapped labels should be added to the --merge-prefix/--issue-prefix section.
- Issues/PRs with no labels should be added to the --merge-prefix/--issue-prefix section unless --add-pr-wo-labels/--add-issues-wo-labels is false.
- Filter both PRs and issues equally.