### PR TITLE
Raise error instead of unhelpful behavior for --since-tag or --due-tag

### DIFF
--- a/lib/github_changelog_generator/generator/generator_tags.rb
+++ b/lib/github_changelog_generator/generator/generator_tags.rb
@@ -135,7 +135,7 @@ module GitHubChangelogGenerator
                             []
                           end
         else
-          Helper.log.warn "Warning: can't find tag #{tag}, specified with --since-tag option."
+          raise ChangelogGeneratorError, "Error: can't find tag #{tag}, specified with --since-tag option."
         end
       end
       filtered_tags
@@ -155,7 +155,7 @@ module GitHubChangelogGenerator
                             []
                           end
         else
-          Helper.log.warn "Warning: can't find tag #{tag}, specified with --due-tag option."
+          raise ChangelogGeneratorError, "Error: can't find tag #{tag}, specified with --due-tag option."
         end
       end
       filtered_tags

--- a/spec/unit/generator/generator_tags_spec.rb
+++ b/spec/unit/generator/generator_tags_spec.rb
@@ -191,24 +191,16 @@ describe GitHubChangelogGenerator::Generator do
 
       context "with invalid since tag" do
         let(:generator) { GitHubChangelogGenerator::Generator.new(since_tag: "Invalid tag") }
-        it { is_expected.to be_a Array }
-        it { is_expected.to match_array(tags_from_strings(%w[1 2 3])) }
+        it { expect { subject }.to raise_error(GitHubChangelogGenerator::ChangelogGeneratorError) }
       end
     end
 
     context "with empty array" do
       subject { generator.filter_since_tag(tags_from_strings(%w[])) }
 
-      context "with valid since tag" do
-        let(:generator) { GitHubChangelogGenerator::Generator.new(since_tag: "2") }
-        it { is_expected.to be_a Array }
-        it { is_expected.to match_array(tags_from_strings(%w[])) }
-      end
-
       context "with invalid since tag" do
         let(:generator) { GitHubChangelogGenerator::Generator.new(since_tag: "Invalid tag") }
-        it { is_expected.to be_a Array }
-        it { is_expected.to match_array(tags_from_strings(%w[])) }
+        it { expect { subject }.to raise_error(GitHubChangelogGenerator::ChangelogGeneratorError) }
       end
     end
   end
@@ -225,24 +217,16 @@ describe GitHubChangelogGenerator::Generator do
 
       context "with invalid due tag" do
         let(:generator) { GitHubChangelogGenerator::Generator.new(due_tag: "Invalid tag") }
-        it { is_expected.to be_a Array }
-        it { is_expected.to match_array(tags_from_strings(%w[1 2 3])) }
+        it { expect { subject }.to raise_error(GitHubChangelogGenerator::ChangelogGeneratorError) }
       end
     end
 
     context "with empty array" do
       subject { generator.filter_due_tag(tags_from_strings(%w[])) }
 
-      context "with valid due tag" do
-        let(:generator) { GitHubChangelogGenerator::Generator.new(due_tag: "2") }
-        it { is_expected.to be_a Array }
-        it { is_expected.to match_array(tags_from_strings(%w[])) }
-      end
-
       context "with invalid due tag" do
         let(:generator) { GitHubChangelogGenerator::Generator.new(due_tag: "Invalid tag") }
-        it { is_expected.to be_a Array }
-        it { is_expected.to match_array(tags_from_strings(%w[])) }
+        it { expect { subject }.to raise_error(GitHubChangelogGenerator::ChangelogGeneratorError) }
       end
     end
   end


### PR DESCRIPTION
Fixes #604

The --since-tag and --due-tag arguments exist to specify tags between
which the changelog should be generated. Prior to this change if these
tags do not exist then GCG continues to generate the entire changelog
which is not what the user requested. This change causes an error
informing the user that their specified tags do not exist so their
request could not be completed.

Other arguments with similar behavior such as --exclude-tags and
--exclude-tags-regex may continue to only give a warning in case the
user made a mistake, but should not error as nonexistent tags are
trivially excluded.