### PR TITLE
Regenerate man, html docs

### DIFF
--- a/man/git-generate-changelog.1
+++ b/man/git-generate-changelog.1
@@ -1,10 +1,10 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "GIT\-GENERATE\-CHANGELOG" "1" "December 2017" "" ""
+.TH "GIT\-GENERATE\-CHANGELOG" "1" "January 2018" "" ""
 .
 .SH "NAME"
-\fBgit\-generate\-changelog\fR \- Generate changelog from github
+\fBgit\-generate\-changelog\fR \- Generate changelog from GitHub
 .
 .SH "SYNOPSIS"
 \fBgit generate\-changelog\fR [\-h|\-\-help] [\-u|\-\-user] [\-p|\-\-project]

--- a/man/git-generate-changelog.1.html
+++ b/man/git-generate-changelog.1.html
@@ -3,7 +3,7 @@
 <head>
   <meta http-equiv='content-type' value='text/html;charset=utf8'>
   <meta name='generator' value='Ronn/v0.7.3 (http://github.com/rtomayko/ronn/tree/0.7.3)'>
-  <title>git-generate-changelog(1) - Generate changelog from github</title>
+  <title>git-generate-changelog(1) - Generate changelog from GitHub</title>
   <style type='text/css' media='all'>
   /* style: man */
   body#manpage {margin:0}
@@ -71,7 +71,7 @@
 
   <h2 id="NAME">NAME</h2>
 <p class="man-name">
-  <code>git-generate-changelog</code> - <span class="man-whatis">Generate changelog from github</span>
+  <code>git-generate-changelog</code> - <span class="man-whatis">Generate changelog from GitHub</span>
 </p>
 
 <h2 id="SYNOPSIS">SYNOPSIS</h2>
@@ -294,7 +294,7 @@
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>December 2017</li>
+    <li class='tc'>January 2018</li>
     <li class='tr'>git-generate-changelog(1)</li>
   </ol>
 


### PR DESCRIPTION
This PR has a regenerated man and HTML documentation file, produced by running `ronn man/git-generate-changelog.md`

This PR closes #606.

Thanks, @benhc123, for that fix!