### PR TITLE
Support printing changelog to stdout

### DIFF
--- a/lib/github_changelog_generator.rb
+++ b/lib/github_changelog_generator.rb
@@ -34,10 +34,14 @@ module GitHubChangelogGenerator
     def run
       log = @generator.compound_changelog
 
-      output_filename = @options[:output].to_s
-      File.open(output_filename, "wb") { |file| file.write(log) }
-      puts "Done!"
-      puts "Generated log placed in #{Dir.pwd}/#{output_filename}"
+      if @options.write_to_file?
+        output_filename = @options[:output].to_s
+        File.open(output_filename, "wb") { |file| file.write(log) }
+        puts "Done!"
+        puts "Generated log placed in #{Dir.pwd}/#{output_filename}"
+      else
+        puts log
+      end
     end
   end
 end

--- a/lib/github_changelog_generator/options.rb
+++ b/lib/github_changelog_generator/options.rb
@@ -112,6 +112,11 @@ module GitHubChangelogGenerator
       !self[:add_sections].nil? && !self[:add_sections].empty?
     end
 
+    # @return [Boolean] whether write to `:output`
+    def write_to_file?
+      self[:output].present?
+    end
+
     private
 
     def values

--- a/lib/github_changelog_generator/parser.rb
+++ b/lib/github_changelog_generator/parser.rb
@@ -50,7 +50,7 @@ module GitHubChangelogGenerator
         opts.on("-f", "--date-format FORMAT", "Date format. Default is %Y-%m-%d") do |last|
           options[:date_format] = last
         end
-        opts.on("-o", "--output [NAME]", "Output file. Default is CHANGELOG.md") do |last|
+        opts.on("-o", "--output [NAME]", "Output file. To print to STDOUT instead, use blank as path. Default is CHANGELOG.md") do |last|
           options[:output] = last
         end
         opts.on("-b", "--base [NAME]", "Optional base file to append generated changes to.") do |last|

--- a/spec/unit/options_spec.rb
+++ b/spec/unit/options_spec.rb
@@ -40,4 +40,28 @@ RSpec.describe GitHubChangelogGenerator::Options do
       end
     end
   end
+
+  describe "#write_to_file?" do
+    subject { options.write_to_file? }
+
+    let(:options) { described_class.new(output: output) }
+
+    context "with filename" do
+      let(:output) { "CHANGELOG.md" }
+
+      it { is_expected.to eq true }
+    end
+
+    context "with nil" do
+      let(:output) { nil }
+
+      it { is_expected.to eq false }
+    end
+
+    context "with empty string" do
+      let(:output) { "" }
+
+      it { is_expected.to eq false }
+    end
+  end
 end


### PR DESCRIPTION
# Background
I want to use `github-changelog-generator` only extract PRs between latest version and current.
Then I write `CHANGELOG.md` with manual formatting. (e.g. write version up Tips, write breaking changes ...)

But `github-changelog-generator` needs file writing.
So I added a feature that print changelog to stdout without file writing.

# Example
```bash
$ github_changelog_generator --user sue445 --project my_repo --stdout --since-tag v1.2.3
(print changelog)
```
