### PR TITLE
Sort issues by detected actual_date instead of closed_at

### DIFF
--- a/lib/github_changelog_generator/generator/generator.rb
+++ b/lib/github_changelog_generator/generator/generator.rb
@@ -92,13 +92,14 @@ module GitHubChangelogGenerator
       Entry.new(options).generate_entry_for_tag(filtered_pull_requests, filtered_issues, newer_tag_name, newer_tag_link, newer_tag_time, older_tag_name)
     end
 
-    # Filters issues and pull requests based on, respectively, `closed_at` and `merged_at`
-    #  timestamp fields.
+    # Filters issues and pull requests based on, respectively, `actual_date`
+    # and `merged_at` timestamp fields. `actual_date` is the detected form of
+    # `closed_at` based on merge event SHA commit times.
     #
     # @return [Array] filtered issues and pull requests
     def filter_issues_for_tags(newer_tag, older_tag)
       filtered_pull_requests = filter_by_tag(@pull_requests, newer_tag)
-      filtered_issues        = delete_by_time(@issues, "closed_at", older_tag, newer_tag)
+      filtered_issues        = delete_by_time(@issues, "actual_date", older_tag, newer_tag)
 
       newer_tag_name = newer_tag.nil? ? nil : newer_tag["name"]
 


### PR DESCRIPTION
Closes #638 

#504 changed issue sorting from using `closed_at` time (the time the user closed the issue) to use `actual_date` (the time of the fix commit reference). #504 was trying to fix PR merge time tag detection (fixed in #619), but the same behavior detection does not apply to issues.

Probably an improved solution to just taking the `actual_date` would be to detect the tag commit of the given sha too, similar to how PRs are sorted. But in my testing this seems to be enough for my use case so far.

Also maybe offer a "Fixed commit: <sha>" options similar to the "Rebased commit: <sha>" ability. Or maybe the milestone functionality could get around it?